### PR TITLE
compatibility with gcc46 on OSX?

### DIFF
--- a/src/HTMLRenderer/state.cc
+++ b/src/HTMLRenderer/state.cc
@@ -23,7 +23,8 @@ namespace pdf2htmlEX {
 
 using std::max;
 using std::abs;
-using std::hypot;
+//using std::hypot;
+using ::hypot;
 
 void HTMLRenderer::updateAll(GfxState * state) 
 { 


### PR DESCRIPTION
I tried to build pdf2htmlEX with GCC 4.6.3 (MacPorts) on Mac OSX (Snow Leopard, 10.6.8) using

```
$ cmake -D CMAKE_C_COMPILER=gcc-mp-4.6 -D CMAKE_CXX_COMPILER=g++-mp-4.6 . 
$ make
```

and got this

```
.../pdf2htmlEX/src/HTMLRenderer/state.cc:27:12: error: 'std::tr1' has not been declared
```

By checking the corresponding line, I found the function `hypot` is under namespace `std`. Since _cmake_ had been included, I took away `std` and rebuilt it. Then the error is gone.
