### PR TITLE
Fix negative font size/transform in CSS output

### DIFF
--- a/src/HTMLRenderer/state.cc
+++ b/src/HTMLRenderer/state.cc
@@ -161,6 +161,15 @@ void HTMLRenderer::check_state_change(GfxState * state)
             new_draw_text_scale = 1.0;
         }
 
+        if(!_is_positive(new_draw_font_size))
+        {
+            // Page is flipped and css can't handle it.
+            new_draw_font_size = -new_draw_font_size;
+
+            for(int i = 0; i < 4; ++i)
+                new_draw_text_tm[i] *= -1;
+        }
+
         if(!(_equal(new_draw_text_scale, draw_text_scale)))
         {
             draw_text_scale_changed = true;


### PR DESCRIPTION
Fix problem with certain pdfs that transform the entire document upside
down, including the fonts, which normally appear correctly in other
renderers. Since CSS doesn't know how to handle negative font sizes, the
document needs to be transformed correctly.
