### PR TITLE
I gave parameters a makeover

### DIFF
--- a/pdf2htmlEX.1.in
+++ b/pdf2htmlEX.1.in
@@ -1,4 +1,4 @@
-.TH pdf2htmlEX 1 "Aug 31, 2012" "pdf2htmlEX 0.1"
+.TH pdf2htmlEX 1
 .SH NAME
 .PP
 .nf
@@ -8,7 +8,7 @@
 .SH USAGE
 .PP
 .nf
-  pdf2htmlEX [options] <input\-filename> [<output\-filename>]
+  pdf2htmlEX [options] <input.pdf> [<output.html>]
 .fi
 
 .SH DESCRIPTION
@@ -23,20 +23,34 @@ Other objects are rendered as images and also embedded.
 
 .SH OPTIONS
 .TP
-.B --help
-Show all options
+.B Pages
 .TP
-.B -v, --version
-Show copyright and version
 .TP
-.B -o, --owner-password <password>
-Specify owner password
+.B -f, --first-page <int> (Default: 1)
+The first page to process
 .TP
-.B -u, --user-password <password>
-Specify user password
+.B -l, --last-page <int> (Default: last page)
+The last page to process
+
+
 .TP
-.B --no-drm <0|1> (Default: 0)
-Override document DRM settings
+.B Dimensions
+.TP
+.B --zoom <ratio>, --fit-width <width>, --fit-height <height>
+--zoom specifies the zoom factor directly; --fit-width/height specifies the maximum width/height of a page, the values are in pixels.
+.TP
+.B --cropbox
+Use the PDF's CropBox instead of MediaBox for output
+.TP
+.B --hdpi <dpi>, --vdpi <dpi> (Default: 144)
+The horizontal and vertical DPI for graphics
+
+
+.TP
+.B Output Files
+.TP
+.B --multiple-files
+Don't embed everything into one HTML file
 .TP
 .B --dest-dir <dir> (Default: .)
 Specify destination folder
@@ -44,57 +58,62 @@ Specify destination folder
 .B --data-dir <dir> (Default: @CMAKE_INSTALL_PREFIX@/share/pdf2htmlEX)
 Specify the folder holding the manifest and other files
 .TP
-.B -f, --first-page <num> (Default: 1)
-Specify the first page to process
-.TP
-.B -l, --last-page <num> (Default: last page)
-Specify the last page to process
-.TP
-.B --zoom <ratio>, --fit-width <width>, --fit-height <height>
---zoom specifies the zoom factor directly; --fit-width/height specifies the maximum width/height of a page, the values are in pixels.
+.B --css-filename <filename> (Default: <none>)
+Specify the filename of the generated css file, if not embedded.
 
 If multiple values are specified, the minimum one will be used.
 
 If none is specified, pages will be rendered as 72DPI.
-.TP
-.B --hdpi <dpi>, --vdpi <dpi> (Default: 144)
-Specify the horizontal and vertical DPI for images
-.TP
-.B --use-cropbox <0|1> (Default: 0)
-Use CropBox instead of MediaBox for output.
-.TP
-.B --process-nontext <0|1> (Default: 1)
-Whether to process non-text objects (as images)
-.TP
-.B --single-html <0|1> (Default: 1)
-Whether to embed everything into one HTML file.
 
-If switched off, there will be several files generated along with the HTML file including files for fonts, css, images.
-.TP
-.B --split-pages <0|1> (Default: 0)
-If turned on, each page is saved in a separated files, also the generated css file will be store separatedly as if single-html=0
 
-The output files will be named as <output-filename>0.page, <output-filename>1.page, ...
 .TP
-.B --embed-base-font <0|1> (Default: 1)
-Whether to embed base 14 fonts.
+.B Embedded Fonts
+.TP
+.B --embed-standard-font
+Whether to embed standard 14 fonts.
 
 There are several base font defined in PDF standards, which are supposed to be provided by the PDF reader.
 
 If this switch is on, local matched font will be used and embedded; otherwise only font names are exported such that web browsers may try to find proper fonts themselves.
 .TP
-.B --embed-external-font <0|1> (Default: 0)
-Similar as above but for non-base fonts.
+.B --embed-external-fonts
+Same as above except for non-standard 14 fonts.
 .TP
-.B --decompose-ligature <0|1> (Default: 0)
+.B --font-suffix <suffix> (Default: .ttf)
+Specify the suffix and format of fonts extracted from the PDF file. If it's empty, the file name will be determined automatically.
+.TP
+.B --decompose-ligatures
 Decompose ligatures. For example 'fi' -> 'f''i'.
 .TP
-.B --heps <len>, --veps <len> (Default: 1)
+.B --keep-unused-glyphs
+Keep unused glyphs in embedded fonts. Results in larger file sizes.
+.TP
+.B --auto-hint
+If set to 1, hints will be generated for the fonts using fontforge. 
+
+This may be preceded by --external-hint-tool.
+.B --external-hint-tool <tool> (Default: <none>)
+If specified, the tool will be called in order to enhanced hinting for fonts, this will precede --auto-hint.
+
+The tool will be called as '<tool> <in.suffix> <out.suffix>', where suffix will be the same as specified for --font-suffix.
+.TP
+.TP
+.B --stretch-narrow-glyphs
+Glyphs narrower than described in PDF will be stretched; otherwise space will be padded to the right of the glyphs
+.TP
+.B --dont-shrink-wide-glyphs
+Truncate wide glyphs rather than shrinking them.
+
+
+.TP
+.B Text
+.TP
+.B --h-merge-threshold <len>, --v-merge-threshold <len> (Default: 1)
 Specify the maximum tolerable horizontal/vertical offset (in pixels).
 
 pdf2htmlEX would try to optimize the generated HTML file moving Text within this distance.
 .TP
-.B --space-threshold <ratio> (Default: 1.0/6)
+.B --word-break-threshold <ratio> (Default: 1.0/8)
 pdf2htmlEX would insert a whitespace character ' ' if the distance between two consecutive letters in the same line is wider than ratio * font_size.
 .TP
 .B --font-size-multiplier <ratio> (Default: 4.0)
@@ -104,10 +123,8 @@ Specify a ratio greater than 1 would resolve this issue, however it might freeze
 
 For some versions of Firefox, however, there will be a problem when the font size is too large, in which case a smaller value should be specified here.
 .TP
-.B --auto-hint <0|1> (Default: 0)
-If set to 1, hints will be generated for the fonts using fontforge. 
-
-This may be preceded by --external-hint-tool. 
+.B --space-as-offset
+Treat space characters as offsets, which may increase the size of the output.
 .TP
 .B --tounicode <-1|0|1> (Default: 0)
 A ToUnicode map may be provided for each font in PDF which indicates the 'meaning' of the characters. However often there is better "ToUnicode" info in Type 0/1 fonts, and sometimes the ToUnicode map provided is wrong. 
@@ -117,49 +134,58 @@ If this value is set to 1, the ToUnicode Map is always applied, if provided in P
 If set to -1, a customized map is used such that rendering will be correct in HTML (visually the same), but you may not get correct characters by select & copy & paste.
 
 If set to 0, pdf2htmlEX would try its best to balance the two methods above.
-.TP
-.B --space-as-offset <0|1> (Default: 0)
-Treat space characters as offsets, which may increase the size of the output.
 
 Turn it on if space characters are not displayed correctly, or you want to remove positional spaces.
-.TP
-.B --stretch-narrow-glyph <0|1> (Default: 0)
-If set to 1, glyphs narrower than described in PDF will be stretched; otherwise space will be padded to the right of the glyphs
-.TP
-.B --squeeze-wide-glyph <0|1> (Default: 1)
-If set to 1, glyphs wider than described in PDF will be squeezed; otherwise it will be truncated.
-.TP
-.B --remove-unused-glyph <0|1> (Default: 1)
-If set to 1, remove unused glyphs in embedded fonts in order to reduce the file size.
-.TP
-.B --font-suffix <suffix> (Default: .ttf), --font-format <format> (Default: truetype)
-Specify the suffix and format of fonts extracted from the PDF file. They should be consistent.
-.TP
-.B --external-hint-tool <tool> (Default: <none>)
-If specified, the tool will be called in order to enhanced hinting for fonts, this will precede --auto-hint.
 
-The tool will be called as '<tool> <in.suffix> <out.suffix>', where suffix will be the same as specified for --font-suffix.
 .TP
-.B --css-filename <filename> (Default: <none>)
-Specify the filename of the generated css file, if not embedded.
+.B Encryption
+.TP
+.B -o, --owner-password <password>
+Specify owner password
+.TP
+.B -u, --user-password <password>
+Specify user password
+.TP
+.B --no-drm
+Override document DRM settings
 
-If it's empty, the file name will be determined automatically.
 .TP
-.B --debug <0|1> (Default: 0)
+.B Misc.
+.TP
+.B --keep-temp
+Keep temporary files after processing.
+.TP
+.B --debug
 Show debug information.
 .TP
-.B --clean-tmp <0|1> (Default: 1)
-If switched off, intermediate files won't be cleaned in the end.
+.B --debug-split-pages
+If turned on, each page is saved in a separated files, also the generated css file will be store separately as if --single-html
+
+The output files will be named as <output-filename>0.page, <output-filename>1.page, ...
+.TP
+.B --no-graphics
+Whether to process graphics (non-text) objects (as images)
+
+If switched off, there will be several files generated along with the HTML file including files for fonts, css, images.
+.TP
+.B --css-draw
+Experimental and unsupported CSS drawing.
+.TP
+.B --help
+Show all options
+.TP
+.B -v, --version
+Show copyright and version
 
 .SH EXAMPLE
 .TP
 .B pdf2htmlEX /path/to/file.pdf
 Convert file.pdf into file.html
 .TP
-.B pdf2htmlEX --clean-tmp 0 --debug 1 /path/to/file.pdf
+.B pdf2htmlEX --keep-temp --debug /path/to/file.pdf
 Convert file.pdf and leave all intermediate files.
 .TP
-.B pdf2htmlEX --dest-dir out --single-html 0 /path/to/file.pdf
+.B pdf2htmlEX --dest-dir out --multiple-files /path/to/file.pdf
 Convert file.pdf into out/file.html and leave font/image files separated.
 
 .SH COPYRIGHT

--- a/src/HTMLRenderer/HTMLRenderer.h
+++ b/src/HTMLRenderer/HTMLRenderer.h
@@ -142,7 +142,7 @@ class HTMLRenderer : public OutputDev
         virtual GBool interpretType3Chars() { return gFalse; }
 
         // Does this device need non-text content?
-        virtual GBool needNonText() { return (param->process_nontext) ? gTrue: gFalse; }
+        virtual GBool needNonText() { return (!param->no_graphics) ? gTrue: gFalse; }
 
         virtual void setDefaultCTM(double *ctm);
 
@@ -241,7 +241,7 @@ class HTMLRenderer : public OutputDev
          * remote font: to be retrieved from the web server
          * local font: to be substituted with a local (client side) font
          */
-        void export_remote_font(const FontInfo & info, const std::string & suffix, const std::string & fontfileformat, GfxFont * font);
+        void export_remote_font(const FontInfo & info, const std::string & suffix, GfxFont * font);
         void export_remote_default_font(long long fn_id);
         void export_local_font(const FontInfo & info, GfxFont * font, const std::string & original_font_name, const std::string & cssfont);
 

--- a/src/HTMLRenderer/export.cc
+++ b/src/HTMLRenderer/export.cc
@@ -18,21 +18,39 @@
 
 namespace pdf2htmlEX {
 
-void HTMLRenderer::export_remote_font(const FontInfo & info, const string & suffix, const string & fontfileformat, GfxFont * font) 
+void HTMLRenderer::export_remote_font(const FontInfo & info, const string & suffix, GfxFont * font) 
 {
+    string mime_type, format;
+    if (suffix == ".ttf") {
+        format = "truetype";
+        mime_type = "application/x-font-ttf";
+    }
+    else if (suffix == ".otf") {
+        format = "opentype";
+        mime_type = "application/x-font-otf";
+    }
+    else if (suffix == ".woff") {
+        format = "woff";
+        mime_type = "application/font-woff";
+    }
+    else if (suffix == ".svg") {
+        format = "svg";
+        mime_type = "image/svg+xml";
+    }
+    
     css_fout << "@font-face{"
         << "font-family:f" << info.id << ";"
         << "src:url(";
 
     {
         auto fn = str_fmt("f%llx%s", info.id, suffix.c_str());
-        if(param->single_html)
+        if(!param->multiple_files)
         {
             auto path = param->tmp_dir + "/" + (char*)fn;
             ifstream fin(path, ifstream::binary);
             if(!fin)
                 throw "Cannot locate font file: " + path;
-            css_fout << "'data:font/" + fontfileformat + ";base64," << base64stream(fin) << "'";
+            css_fout << "'data:font/" + mime_type + ";base64," << base64stream(fin) << "'";
         }
         else
         {
@@ -41,7 +59,7 @@ void HTMLRenderer::export_remote_font(const FontInfo & info, const string & suff
     }
 
     css_fout << ")"
-        << "format(\"" << fontfileformat << "\");"
+        << "format(\"" << format << "\");"
         << "}" // end of @font-face
         << ".f" << info.id << "{"
         << "font-family:f" << info.id << ";"

--- a/src/HTMLRenderer/install.cc
+++ b/src/HTMLRenderer/install.cc
@@ -110,7 +110,7 @@ void HTMLRenderer::install_embedded_font(GfxFont * font, FontInfo & info)
     if(path != "")
     {
         embed_font(path, font, info);
-        export_remote_font(info, param->font_suffix, param->font_format, font);
+        export_remote_font(info, param->font_suffix, font);
     }
     else
     {
@@ -129,7 +129,7 @@ void HTMLRenderer::install_base_font(GfxFont * font, GfxFontLoc * font_loc, Font
         if(localfontloc != nullptr)
         {
             embed_font(localfontloc->path->getCString(), font, info);
-            export_remote_font(info, param->font_suffix, param->font_format, font);
+            export_remote_font(info, param->font_suffix, font);
             delete localfontloc;
             return;
         }
@@ -186,7 +186,7 @@ void HTMLRenderer::install_external_font(GfxFont * font, FontInfo & info)
         if(localfontloc != nullptr)
         {
             embed_font(string(localfontloc->path->getCString()), font, info);
-            export_remote_font(info, param->font_suffix, param->font_format, font);
+            export_remote_font(info, param->font_suffix, font);
             delete localfontloc;
             return;
         }

--- a/src/HTMLRenderer/text.cc
+++ b/src/HTMLRenderer/text.cc
@@ -413,7 +413,7 @@ void HTMLRenderer::embed_font(const string & filepath, GfxFont * font, FontInfo 
             }
         }
 
-        ffw_set_widths(width_list, max_key + 1, param->stretch_narrow_glyph, param->squeeze_wide_glyph, param->remove_unused_glyph);
+        ffw_set_widths(width_list, max_key + 1, param->stretch_narrow_glyph, !param->dont_shrink_wide_glyph, !param->keep_unused_glyph);
         
         ffw_reencode_raw(cur_mapping, max_key + 1, 1);
 
@@ -485,10 +485,10 @@ void HTMLRenderer::embed_font(const string & filepath, GfxFont * font, FontInfo 
      * Reload to retrieve/fix accurate ascent/descent
      */
     string fn = (char*)str_fmt("%s/f%llx%s", 
-        (param->single_html ? param->tmp_dir : param->dest_dir).c_str(),
+        (!param->multiple_files ? param->tmp_dir : param->dest_dir).c_str(),
         info.id, param->font_suffix.c_str());
 
-    if(param->single_html)
+    if(!param->multiple_files)
         tmp_files.add(fn);
 
     ffw_load_font(cur_tmp_fn.c_str());

--- a/src/Param.h
+++ b/src/Param.h
@@ -31,8 +31,8 @@ struct Param
     double h_dpi, v_dpi;
     int use_cropbox;
 
-    int process_nontext;
-    int single_html;
+    int no_graphics;
+    int multiple_files;
     int split_pages;
     int embed_base_font;
     int embed_external_font;
@@ -53,10 +53,10 @@ struct Param
     int tounicode;
     int space_as_offset;
     int stretch_narrow_glyph;
-    int squeeze_wide_glyph;
-    int remove_unused_glyph;
+    int dont_shrink_wide_glyph;
+    int keep_unused_glyph;
 
-    std::string font_suffix, font_format;
+    std::string font_suffix;
     std::string external_hint_tool;
 
     /*
@@ -68,7 +68,7 @@ struct Param
      * Debug
      */
     int debug;
-    int clean_tmp;
+    int keep_temp;
 
     // experimental
     int css_draw;

--- a/src/pdf2htmlEX-config.h.in
+++ b/src/pdf2htmlEX-config.h.in
@@ -16,7 +16,6 @@
 namespace pdf2htmlEX {
 
 static const std::string PDF2HTMLEX_VERSION = "@PDF2HTMLEX_VERSION@";
-static const std::string PDF2HTMLEX_PREFIX = "@CMAKE_INSTALL_PREFIX@";
 static const std::string PDF2HTMLEX_DATA_PATH = "@CMAKE_INSTALL_PREFIX@""/share/pdf2htmlEX";
 
 } // namespace pdf2htmlEX

--- a/src/pdf2htmlEX.cc
+++ b/src/pdf2htmlEX.cc
@@ -36,13 +36,8 @@ ArgParser argparser;
 
 void show_usage_and_exit(const char * dummy = nullptr)
 {
-    cerr << "Usage: pdf2htmlEX [Options] <input.pdf> [<output.html>]" << endl;
-    cerr << endl;
-    cerr << "Options:" << endl;
+    cerr << "Usage: pdf2htmlEX [options] <input.pdf> [<output.html>]" << endl;
     argparser.show_usage(cerr);
-    cerr << endl;
-    cerr << "Run 'man pdf2htmlEX' for detailed information" << endl;
-    cerr << endl;
     exit(EXIT_FAILURE);
 }
 
@@ -59,52 +54,58 @@ void show_version_and_exit(const char * dummy = nullptr)
 void parse_options (int argc, char **argv)
 {
     argparser
-        .add("help,h", "show all options", &show_usage_and_exit)
-        .add("version,v", "show copyright and version info", &show_version_and_exit)
-
+        // pages
+        .add("first-page,f", &param.first_page, 1, "first page to convert", nullptr, true)
+        .add("last-page,l", &param.last_page, numeric_limits<int>::max(), "last page to convert", nullptr, true)
+        
+        // dimensions
+        .add("zoom", &param.zoom, 0, "zoom ratio", nullptr, true)
+        .add("fit-width", &param.fit_width, 0, "fit width to <fp> pixels", nullptr, true)
+        .add("fit-height", &param.fit_height, 0, "fit height to <fp> pixels", nullptr, true)
+        .add("cropbox", "use CropBox instead of MediaBox", [](const char*) { param.use_cropbox = 1; })
+        .add("hdpi", &param.h_dpi, 144.0, "horizontal resolution for graphics in DPI")
+        .add("vdpi", &param.v_dpi, 144.0, "vertical resolution for graphics in DPI")
+        
+         // output files
+        .add("multiple-files", "don't combine all output into a single HTML file", [](const char*) { param.multiple_files = 1; })
+        .add("dest-dir", &param.dest_dir, ".", "destination directory", nullptr, true)
+        .add("data-dir", &param.data_dir, PDF2HTMLEX_DATA_PATH, "data directory")
+        .add("css-filename", &param.css_filename, "", "filename of the generated CSS file", nullptr, true)
+        
+        // embedded fonts
+        .add("embed-standard-fonts", "embed local match for standard 14 fonts", [](const char*) { param.embed_base_font = 1; })
+        .add("embed-external-fonts", "embed local match for external fonts", [](const char*) { param.embed_external_font = 1; })
+        .add("font-suffix", &param.font_suffix, ".ttf", "format for embedded font files (.ttf*,.otf,.woff,.svg)", nullptr, true)
+        .add("decompose-ligatures", "decompose ligatures, such as \uFB01 -> fi", [](const char*) { param.decompose_ligature = 1; })
+        .add("keep-unused-glyphs", "keep unused glyphs in embedded fonts", [](const char*) { param.keep_unused_glyph = 1; })
+        .add("auto-hint", "use fontforge autohint on fonts without hints", [](const char*) { param.auto_hint = 1; })
+        .add("external-hint-tool", &param.external_hint_tool, "", "external tool for hinting fonts (overrides --auto-hint)", nullptr, true)
+        .add("stretch-narrow-glyphs", "stretch narrow glyphs instead of padding them", [](const char*) { param.stretch_narrow_glyph = 1; })
+        .add("dont-shrink-wide-glyphs", "truncating wide glyphs instead of shrinking them", [](const char*) { param.dont_shrink_wide_glyph = 1; })
+        
+        // text
+        .add("h-merge-threshold", &param.h_eps, 1.0, "horizontal threshold for merging text, in pixels")
+        .add("v-merge-threshold", &param.v_eps, 1.0, "vertical threshold for merging text, in pixels")
+        .add("word-break-threshold", &param.space_threshold, (1.0/8), "word break threshold (threshold * em)")
+        .add("font-size-multiplier", &param.font_size_multiplier, 4.0, "a value greater than 1 increases the rendering accuracy")
+        .add("space-as-offset", "treat space characters as offsets", [](const char*) { param.space_as_offset = 1; })
+        .add("tounicode", &param.tounicode, 0, "how to handle ToUnicode CMaps (0=auto*, 1=force, -1=ignore)", nullptr, true)
+        
+        // encryption
         .add("owner-password,o", &param.owner_password, "", "owner password (for encrypted files)", nullptr, true)
         .add("user-password,u", &param.user_password, "", "user password (for encrypted files)", nullptr, true)
-        .add("no-drm", &param.no_drm, 0, "override document DRM settings")
-
-        .add("dest-dir", &param.dest_dir, ".", "specify destination directory")
-        .add("data-dir", &param.data_dir, PDF2HTMLEX_DATA_PATH, "specify data directory")
-
-        .add("first-page,f", &param.first_page, 1, "first page to process")
-        .add("last-page,l", &param.last_page, numeric_limits<int>::max(), "last page to process")
-
-        .add("zoom", &param.zoom, 0, "zoom ratio", nullptr, true)
-        .add("fit-width", &param.fit_width, 0, "fit width to <arg> pixels", nullptr, true) 
-        .add("fit-height", &param.fit_height, 0, "fit height to <arg> pixels", nullptr, true)
-        .add("hdpi", &param.h_dpi, 144.0, "horizontal DPI for non-text")
-        .add("vdpi", &param.v_dpi, 144.0, "vertical DPI for non-text")
-        .add("use-cropbox", &param.use_cropbox, 0, "use CropBox instead of MediaBox")
-
-        .add("process-nontext", &param.process_nontext, 1, "process nontext objects")
-        .add("single-html", &param.single_html, 1, "combine everything into one single HTML file")
-        .add("split-pages", &param.split_pages, 0, "split pages into separated files")
-        .add("embed-base-font", &param.embed_base_font, 0, "embed local matched font for base 14 fonts in the PDF file")
-        .add("embed-external-font", &param.embed_external_font, 0, "embed local matched font for external fonts in the PDF file")
-        .add("decompose-ligature", &param.decompose_ligature, 0, "decompose ligatures, for example 'fi' -> 'f''i'")
-
-        .add("heps", &param.h_eps, 1.0, "max tolerated horizontal offset (in pixels)")
-        .add("veps", &param.v_eps, 1.0, "max tolerated vertical offset (in pixels)")
-        .add("space-threshold", &param.space_threshold, (1.0/8), "distance no thiner than (threshold * em) will be considered as a space character")
-        .add("font-size-multiplier", &param.font_size_multiplier, 4.0, "setting a value greater than 1 would increase the rendering accuracy")
-        .add("auto-hint", &param.auto_hint, 0, "Whether to generate hints for fonts")
-        .add("tounicode", &param.tounicode, 0, "Specify how to deal with ToUnicode map, 0 for auto, 1 for forced, -1 for disabled")
-        .add("space-as-offset", &param.space_as_offset, 0, "treat space characters as offsets")
-        .add("stretch-narrow-glyph", &param.stretch_narrow_glyph, 0, "stretch narrow glyphs instead of padding space")
-        .add("squeeze-wide-glyph", &param.squeeze_wide_glyph, 1, "squeeze wide glyphs instead of truncating")
-        .add("remove-unused-glyph", &param.remove_unused_glyph, 1, "remove unused glyphs in embedded fonts")
-
-        .add("font-suffix", &param.font_suffix, ".ttf", "suffix for extracted font files")
-        .add("font-format", &param.font_format, "opentype", "format for extracted font files")
-        .add("external-hint-tool", &param.external_hint_tool, "", "external tool for hintting fonts.(overrides --auto-hint)")
-        .add("css-filename", &param.css_filename, "", "Specify the file name of the generated css file")
-
-        .add("debug", &param.debug, 0, "output debug information")
-        .add("clean-tmp", &param.clean_tmp, 1, "clean temporary files after processing")
-        .add("css-draw", &param.css_draw, 0, "[Experimental and Unsupported] CSS Drawing")
+        .add("no-drm", "override document DRM settings", [](const char*) { param.no_drm = 1; })
+        
+        // misc.
+        .add("keep-temp", "keep temporary files after processing", [](const char*) { param.keep_temp = 1; })
+        .add("debug", "[debug] print debug information", [](const char*) { param.debug = 1; })
+        .add("debug-split-pages", "[debug] split pages into separate .page files", [](const char*) { param.split_pages = 1; })
+        .add("no-graphics", "do not output any graphics",  [](const char*) { param.no_graphics = 1; })
+        .add("css-draw", "[experimental and unsupported] CSS drawing", [](const char*) { param.css_draw = 1; })
+        
+        .add("version,v", "print copyright and version info", &show_version_and_exit)
+        .add("help,h", "print usage information", &show_usage_and_exit)
+        
         .add("", &param.input_filename, "", "")
         .add("", &param.output_filename, "", "")
         ;
@@ -140,10 +141,9 @@ int main(int argc, char **argv)
     parse_options(argc, argv);
     if (param.input_filename == "")
     {
-        cerr << "Missing input filename" << endl;
-        exit(EXIT_FAILURE);
+        show_usage_and_exit();
     }
-
+    
     //prepare the directories
     {
         char buf[] = "/tmp/pdf2htmlEX-XXXXXX";

--- a/src/util/ArgParser.cc
+++ b/src/util/ArgParser.cc
@@ -164,6 +164,6 @@ ArgParser::ArgEntryBase::ArgEntryBase(const char * name, const char * descriptio
     }
 }
 
-const int ArgParser::arg_col_width = 40;
+const int ArgParser::arg_col_width = 32;
 
 } // namespace pdf2htmlEX

--- a/src/util/ArgParser.h
+++ b/src/util/ArgParser.h
@@ -39,6 +39,23 @@ void dump_value(std::ostream & out, const T & v)
 
 extern void dump_value(std::ostream & out, const std::string & v);
 
+// type names helper
+template<typename> 
+struct type_name {
+    static char const* value() { return "unknown"; }
+};
+
+template<> struct type_name<int> {
+    static char const* value() { return "int"; }
+};
+
+template<> struct type_name<double> {
+    static char const* value() { return "fp"; }
+};
+
+template<> struct type_name<std::string> {
+    static char const* value() { return "string"; }
+};
 
 class ArgParser
 {
@@ -161,13 +178,7 @@ void ArgParser::ArgEntry<T, Tv>::show_usage(std::ostream & out) const
 
     if(need_arg)
     {
-        sout << " <arg>";
-        if(!dont_show_default)
-        {
-            sout << " (=";
-            dump_value(sout, default_value);
-            sout << ")";
-        }
+        sout << " <" << type_name<T>::value() << ">";
     }
 
     std::string s = sout.str();
@@ -176,7 +187,16 @@ void ArgParser::ArgEntry<T, Tv>::show_usage(std::ostream & out) const
     for(int i = s.size(); i < arg_col_width; ++i)
         out << ' ';
 
-    out << " " << description << std::endl;
+    out << " " << description;
+    
+    if(need_arg && !dont_show_default)
+    {
+        out << " (default is ";
+        dump_value(out, default_value);
+        out << ")";
+    }
+    
+    out << std::endl;
 }
 
 } // namespace ArgParser

--- a/src/util/TmpFiles.cc
+++ b/src/util/TmpFiles.cc
@@ -27,7 +27,7 @@ TmpFiles::~TmpFiles()
 
 void TmpFiles::add( const string & fn)
 {
-    if(!param.clean_tmp)
+    if(param.keep_temp)
         return;
 
     if(tmp_files.insert(fn).second && param.debug)
@@ -36,7 +36,7 @@ void TmpFiles::add( const string & fn)
 
 void TmpFiles::clean()
 {
-    if(!param.clean_tmp)
+    if(param.keep_temp)
         return;
 
     for(auto iter = tmp_files.begin(); iter != tmp_files.end(); ++iter)


### PR DESCRIPTION
I've improved the command line parameters:
- All 0/1 parameters are now flags, so we can write `--debug` instead of `--debug 1`. This was done using a C++11 lambda.
- All flags are now _off_ by default, and setting them turns them on, so I've had to invert some of the names, e.g. `--squeeze-wide-glyphs 0` -> `--dont-squeeze-wide-glyphs`.
- Some parameters with confusing names have been re-named (unfair advantage: I'm English) and to keep them consistent with Poppler's _pdftocairo_ and _pdftohtml_.
- The `ArgParser` now prints out the type instead of `<arg>`, using template magic.
