### PR TITLE
bugfix: mime types for data uri fonts

### DIFF
--- a/src/HTMLRenderer/font.cc
+++ b/src/HTMLRenderer/font.cc
@@ -732,7 +732,7 @@ void HTMLRenderer::export_remote_font(const FontInfo & info, const string & suff
             ifstream fin(path, ifstream::binary);
             if(!fin)
                 throw "Cannot locate font file: " + path;
-            f_css.fs << "'data:font/" + mime_type + ";base64," << base64stream(fin) << "'";
+            f_css.fs << "'data:" + mime_type + ";base64," << base64stream(fin) << "'";
         }
         else
         {


### PR DESCRIPTION
The `font/` prefix from the old code was accidentally left in when I changed this. Chrome was unhappy.
