### PR TITLE
process_outline creates outline file even if process_outline is disabled

### DIFF
--- a/src/HTMLRenderer/general.cc
+++ b/src/HTMLRenderer/general.cc
@@ -301,6 +301,7 @@ void HTMLRenderer::pre_process(PDFDoc * doc)
         set_stream_flags(f_css.fs);
     }
 
+    if (param->process_outline)
     {
         /*
          * The logic for outline is similar to css


### PR DESCRIPTION
`process_outline` creates outline file even if `process_outline` is disabled. I have tested it with `split-pages 1`.
