### PR TITLE
process_outline 0 was trying to write manifest which did not exists.

### DIFF
--- a/src/HTMLRenderer/general.cc
+++ b/src/HTMLRenderer/general.cc
@@ -415,7 +415,7 @@ void HTMLRenderer::post_process(void)
                 {
                     ifstream fin(f_outline.path, ifstream::binary);
                     if(!fin)
-                        throw "Cannot open read the pages";
+                        throw "Cannot open outline for reading";
                     output << fin.rdbuf();
                     output.clear(); // output will set fail big if fin is empty
                 }
@@ -424,7 +424,7 @@ void HTMLRenderer::post_process(void)
             {
                 ifstream fin(f_pages.path, ifstream::binary);
                 if(!fin)
-                    throw "Cannot open read the pages";
+                    throw "Cannot open pages for reading";
                 output << fin.rdbuf();
                 output.clear(); // output will set fail big if fin is empty
             }


### PR DESCRIPTION
Probably it was side effect of previous merge request which conditionally generates outline file resulting `Error: Cannot open read the pages.` This patch fix this problem, additionally it close outline file if it opened.
