### PR TITLE
Simple text clipping

### DIFF
--- a/src/HTMLRenderer/text.cc
+++ b/src/HTMLRenderer/text.cc
@@ -104,13 +104,17 @@ void HTMLRenderer::drawString(GfxState * state, GooString * s)
         double dev_total_dx, dev_total_dy;
         state->textTransformDelta(total_dx, total_dy, &dev_total_dx, &dev_total_dy);
         state->transformDelta(dev_total_dx, dev_total_dy, &dev_total_dx, &dev_total_dy);
+        dev_total_dx *= text_zoom_factor();
+        dev_total_dy *= text_zoom_factor();
         
         double dummy, dev_dx;
         state->textTransformDelta(dx, 0, &dev_dx, &dummy);
         state->transformDelta(dev_dx, 0, &dev_dx, &dummy);
+        dev_dx *= text_zoom_factor();
         
         double dev_height;
         state->transformDelta(0, state->getFontSize(), &dummy, &dev_height);
+        dev_height *= text_zoom_factor();
         
         double dev_descent = dev_height * font->getDescent();
         


### PR DESCRIPTION
Here's my attempt at text clipping, using `GfxState::getClipBBox` which returns a rectangle which bounds the clipping path. I simply transform the character positions from text space to device space and check if they fall completely outside of the clipping rectangle. If it does, then an offset is inserted in its place.

This is the simplest possible implementation I could think of. It could be enhanced by detecting partially clipped characters (easy) and somehow tagging them as clipped, and then use the CSS `clip` property on them. That'll work for rectangles only, but that's probably 95% of the real use cases.
