### PR TITLE
We are not printing, so we need this after all

### DIFF
--- a/src/BackgroundRenderer/CairoBackgroundRenderer.cc
+++ b/src/BackgroundRenderer/CairoBackgroundRenderer.cc
@@ -79,6 +79,7 @@ void CairoBackgroundRenderer::render_page(PDFDoc * doc, int pageno)
 
     cairo_t * cr = cairo_create(surface);
     setCairo(cr);
+    setPrinting(false);
 
     doc->displayPage(this, pageno, param.h_dpi, param.v_dpi,
             0, 


### PR DESCRIPTION
I ran some tests and noticed that we need setPrinting(false) here after all. Otherwise, some bitmap images end up as negatives (wrong color space).
