### PR TITLE
Remove libpopplerXX from the dependency list. #341

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://github.com/coolwanglu/pdf2htmlEX
 
 Package: pdf2htmlex
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libpng12-0, libjpeg8
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Suggests: ttfautohint
 Description: Converts PDF to HTML without losing format
  pdf2htmlEX converts PDF to HTML while retaining text, format & style as much as possible


### PR DESCRIPTION
The right dependency on libpopplerXX is automatically set by ${shlibs:Depends}.
