### PR TITLE
Fix issue of calling abs() in C stdlib

### DIFF
--- a/src/HTMLRenderer/link.cc
+++ b/src/HTMLRenderer/link.cc
@@ -230,7 +230,7 @@ void HTMLRenderer::processLink(AnnotLink * al)
                         x, y, w, h,
                         border_top_bottom_width, border_left_right_width);
 
-                if(abs(border_top_bottom_width - border_left_right_width) < EPS)
+                if(std::abs(border_top_bottom_width - border_left_right_width) < EPS)
                     (*f_curpage) << "border-width:" << round(border_top_bottom_width) << "px;";
                 else
                     (*f_curpage) << "border-width:" << round(border_top_bottom_width) << "px " << round(border_left_right_width) << "px;";

--- a/src/HTMLTextLine.cc
+++ b/src/HTMLTextLine.cc
@@ -168,7 +168,7 @@ void HTMLTextLine::dump_text(ostream & out)
                 double actual_offset = 0;
 
                 //ignore near-zero offsets
-                if(abs(target) <= param.h_eps)
+                if(std::abs(target) <= param.h_eps)
                 {
                     actual_offset = 0;
                 }
@@ -179,7 +179,7 @@ void HTMLTextLine::dump_text(ostream & out)
                     if(!(state_iter1->hash_umask & State::umask_by_id(State::WORD_SPACE_ID)))
                     {
                         double space_off = state_iter1->single_space_offset();
-                        if(abs(target - space_off) <= param.h_eps)
+                        if(std::abs(target - space_off) <= param.h_eps)
                         {
                             Unicode u = ' ';
                             writeUnicodes(out, &u, 1);
@@ -351,7 +351,7 @@ void HTMLTextLine::optimize_normal(std::vector<HTMLTextLine*> & lines)
             {
                 const double target = off_iter->width;
                 auto iter = width_map.lower_bound(target-EPS);
-                if((iter != width_map.end()) && (abs(iter->first - target) <= EPS))
+                if((iter != width_map.end()) && (std::abs(iter->first - target) <= EPS))
                 {
                     ++ iter->second;
                 }

--- a/src/StateManager.h
+++ b/src/StateManager.h
@@ -44,7 +44,7 @@ public:
     // return the corresponding id
     long long install(double new_value, double * actual_value_ptr = nullptr) {
         auto iter = value_map.lower_bound(new_value - eps);
-        if((iter != value_map.end()) && (abs(iter->first - new_value) <= eps)) 
+        if((iter != value_map.end()) && (std::abs(iter->first - new_value) <= eps))
         {
             if(actual_value_ptr != nullptr)
                 *actual_value_ptr = iter->first;


### PR DESCRIPTION
In `StateManager::install()` expression `abs(iter->first - new_value) <= eps)` actually calls `int abs(int)` in C stdlib, and doesn't work for `eps` less than 2 (e.g. `abs(1.99) <= 1`). This issue can result in significant positioning errors.

I also search for all callings to `abs()` and change them to explicit `std::abs()` (`fabs()` should work too) to avoid this type of confusion.
