### PR TITLE
Change output format to xhtml, and enable --output-filename option.

### DIFF
--- a/share/manifest
+++ b/share/manifest
@@ -17,11 +17,11 @@
 """
 <!DOCTYPE html>
 <!-- Created by pdf2htmlEX (https://github.com/coolwanglu/pdf2htmlex) -->
-<html>
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<meta charset="utf-8">
-<meta name="generator" content="pdf2htmlEX">
-<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+<meta charset="utf-8"/>
+<meta name="generator" content="pdf2htmlEX"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
 """
 
 #############

--- a/share/pdf2htmlEX.js.in
+++ b/share/pdf2htmlEX.js.in
@@ -273,7 +273,7 @@ Viewer.prototype = {
       var nodes = this.outline.childNodes;
       for (var i = 0, l = nodes.length; i < l; ++i) {
         var cur_node = nodes[i];
-        if (cur_node.nodeName === 'UL') {
+        if (cur_node.nodeName.toLowerCase() === 'ul') {
           empty = false;
           break;
         }

--- a/src/util/const.cc
+++ b/src/util/const.cc
@@ -35,9 +35,9 @@ const std::map<std::string, EmbedStringEntry> EMBED_STRING_MAP({
              "\"></script>" }},
     {".png", {&Param::embed_image,
              "<img alt=\"\" src=\"data:image/png;base64,", 
-             "\">", true,
+             "\"/>", true,
              "<img alt=\"\" src=\"",
-             "\">" }}
+             "\"/>" }}
 });
 
 const std::map<std::string, std::string> FORMAT_MIME_TYPE_MAP({


### PR DESCRIPTION
XHTML format is better for post-processing than HTML, because many platforms/languages are lacking a decent HTML5 parser, but most of them have good XML parsers. XHTML is also required by Epub.

XHTML files have extension ".xhtml" or ".xht" but the default is ".html", so It is necessary to enable the `--output-filename` option.
