### PR TITLE
fix typo: generalise error message

### DIFF
--- a/src/BackgroundRenderer/SplashBackgroundRenderer.cc
+++ b/src/BackgroundRenderer/SplashBackgroundRenderer.cc
@@ -232,7 +232,7 @@ void SplashBackgroundRenderer::dump_image(const char * filename, int x1, int y1,
     }
 
     if(!writer->init(f, width, height, param.h_dpi, param.v_dpi))
-        throw "Cannot initialize PNGWriter";
+        throw "Cannot initialize image writer";
         
     auto * bitmap = getBitmap();
     assert(bitmap->getMode() == splashModeRGB8);


### PR DESCRIPTION
The error message was previously saying it failed to initialise the PNGWriter, when really it could've been any of the three image writers.

This patch makes the error message more clear, increasing debug-ability.
