### PR TITLE
Workaround spaces issues of blink/webkit

### DIFF
--- a/share/base.css.in
+++ b/share/base.css.in
@@ -161,15 +161,21 @@
   /* Workaround for https://bugs.webkit.org/show_bug.cgi?id=35443 */
   content: '';
 }
+.@CSS_LINE_CN@:before {
+  /* Workaround Blink(up to 41)/Webkit bug of word-spacing with leading spaces (chromium #404444 and pdf2htmlEX #412) */
+  content: '';
+  display: inline-block;
+}
 .@CSS_LINE_CN@ span { /* text blocks within a line */
+  /* Blink(up to 41)/Webkit have bug with negative word-spacing and inline-block (pdf2htmlEX #416), so keep normal span inline. */
   position:relative;
-  /* _<id> for spaces may need display:inline, which will override this */ 
-  display:inline-block;
   unicode-bidi:bidi-override; /* For rtl languages, e.g. Hebrew, we don't want the default Unicode behaviour */
 }
 .@CSS_WHITESPACE_CN@ { /* text shift */
-  color:transparent;
-  z-index:-1;
+  /* Blink(up to 41)/Webkit have bug with inline element, continuous spaces and word-spacing. Workaround by inline-block. */
+  display: inline-block;
+  color: transparent;
+  z-index: -1;
 }
 /* selection background should not be opaque, for fallback mode */
 ::selection{

--- a/src/HTMLTextLine.cc
+++ b/src/HTMLTextLine.cc
@@ -247,11 +247,7 @@ void HTMLTextLine::dump_text(ostream & out)
                     if(!(state_iter1->hash_umask & State::umask_by_id(State::WORD_SPACE_ID)))
                     {
                         double space_off = state_iter1->single_space_offset();
-                        if((std::abs(target - space_off) <= param.h_eps)
-                                // Chrome/webkit don't apply CSS word-spacing to leading spaces, so we don't
-                                // convert leading offsets to spaces. See also issue #412 and chromium issue #404444.
-                                // TODO after browsers having this bug have vanished, just remove the line below.
-                                && ((state_iter1->word_space == 0) || (cur_offset_iter->start_idx != 0)))
+                        if(std::abs(target - space_off) <= param.h_eps)
                         {
                             Unicode u = ' ';
                             writeUnicodes(out, &u, 1);

--- a/src/StateManager.h
+++ b/src/StateManager.h
@@ -245,15 +245,15 @@ public:
     static const char * get_css_class_name (void) { return CSS::WHITESPACE_CN; }
     double default_value(void) { return 0; }
     void dump_value(std::ostream & out, double value) { 
-        out << ((value > 0) ? "display:inline-block;width:" 
-                            : "display:inline;margin-left:")
+        out << ((value > 0) ? "width:"
+                            : "margin-left:")
             << round(value) << "px;";
     }
     void dump_print_value(std::ostream & out, double value, double scale) 
     {
         value *= scale;
-        out << ((value > 0) ? "display:inline-block;width:" 
-                            : "display:inline;margin-left:")
+        out << ((value > 0) ? "width:"
+                            : "margin-left:")
             << round(value) << "pt;";
     }
 };


### PR DESCRIPTION
This patch (hopefully) resolve #412, #416, and #483. PR #414 is unnecessary now, so revert it to simplify the code.

Test cases in above issues look fine in chrome now.
