### PR TITLE
Convert illegal html unicode without glyph to space or zero-width space.

### DIFF
--- a/3rdparty/poppler/git/CairoFontEngine.cc
+++ b/3rdparty/poppler/git/CairoFontEngine.cc
@@ -377,6 +377,7 @@ _ft_new_face (FT_Library lib,
 
 CairoFreeTypeFont::CairoFreeTypeFont(Ref ref,
 				     cairo_font_face_t *cairo_font_face,
+				     FT_Face ft_face,
 				     int *codeToGID,
 				     Guint codeToGIDLen,
 				     GBool substitute) : CairoFont(ref,
@@ -384,7 +385,10 @@ CairoFreeTypeFont::CairoFreeTypeFont(Ref ref,
 								   codeToGID,
 								   codeToGIDLen,
 								   substitute,
-								   gTrue) { }
+								   gTrue),
+								   // Caution: this field is added by pdf2htmlEX to determine whitespace. Please merge during update.
+								   ft_face(ft_face)
+                                    { }
 
 CairoFreeTypeFont::~CairoFreeTypeFont() { }
 
@@ -546,7 +550,7 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref,
 
   delete fontLoc;
   return new CairoFreeTypeFont(ref,
-		       font_face,
+		       font_face, face,
 		       codeToGID, codeToGIDLen,
 		       substitute);
 

--- a/3rdparty/poppler/git/CairoFontEngine.h
+++ b/3rdparty/poppler/git/CairoFontEngine.h
@@ -75,10 +75,12 @@ class CairoFreeTypeFont : public CairoFont {
 public:
   static CairoFreeTypeFont *create(GfxFont *gfxFont, XRef *xref, FT_Library lib, GBool useCIDs);
   virtual ~CairoFreeTypeFont();
-
+  // Caution: this function is added by pdf2htmlEX to determine whitespace. Please merge during update.
+  FT_Face get_ft_face() { return ft_face; }
 private:
-  CairoFreeTypeFont(Ref ref, cairo_font_face_t *cairo_font_face,
+  CairoFreeTypeFont(Ref ref, cairo_font_face_t *cairo_font_face, FT_Face ft_face,
 	    int *codeToGID, Guint codeToGIDLen, GBool substitute);
+  FT_Face ft_face;
 };
 
 //------------------------------------------------------------------------

--- a/src/HTMLRenderer/HTMLRenderer.h
+++ b/src/HTMLRenderer/HTMLRenderer.h
@@ -12,6 +12,8 @@
 #include <fstream>
 #include <memory>
 
+#include <ft2build.h>
+#include FT_FREETYPE_H
 #include <OutputDev.h>
 #include <GfxState.h>
 #include <Stream.h>
@@ -42,6 +44,7 @@
 #include "util/const.h"
 #include "util/misc.h"
 
+class CairoFontEngine;
 
 namespace pdf2htmlEX {
 
@@ -217,6 +220,10 @@ protected:
     // make sure the current HTML style consistent with PDF
     void prepare_text_line(GfxState * state);
 
+    // Check whether this char has a non-empty glyph in this font. If not sure, return true.
+    // A char has an empty glyph or no glyph is usually a whitespace.
+    bool has_glyph(CharCode code, GfxFont* font);
+
     ////////////////////////////////////////////////////
     // PDF stuffs
     ////////////////////////////////////////////////////
@@ -341,6 +348,11 @@ protected:
 
     CoveredTextDetector covered_text_detector;
     DrawingTracer tracer;
+
+#if ENABLE_SVG
+    FT_Library ft_lib;
+    std::unique_ptr<CairoFontEngine> font_engine;
+#endif
 };
 
 } //namespace pdf2htmlEX

--- a/src/HTMLRenderer/font.cc
+++ b/src/HTMLRenderer/font.cc
@@ -38,6 +38,7 @@
 #include "CairoFontEngine.h"
 #include "CairoOutputDev.h"
 #include <Gfx.h>
+#include FT_OUTLINE_H
 #endif
 
 namespace pdf2htmlEX {
@@ -1080,6 +1081,31 @@ void HTMLRenderer::export_local_font(const FontInfo & info, GfxFont * font, cons
     f_css.fs << "visibility:visible;";
 
     f_css.fs << "}" << endl;
+}
+
+bool HTMLRenderer::has_glyph(CharCode code, GfxFont* font)
+{
+#if ENABLE_SVG
+    if (font->getType() == fontType3)
+        return true;
+    CairoFreeTypeFont* ftfont = (CairoFreeTypeFont*)font_engine->getFont(font, cur_doc, false, xref);
+    if (ftfont == nullptr)
+        return false;
+    FT_Face face = ftfont->get_ft_face();
+    if (face == nullptr)
+        return false;
+    auto gid = ftfont->getGlyph(code, nullptr, 0);
+    // gid == 0 means no glyph
+    if (gid == 0)
+        return false;
+    if (FT_Load_Glyph(face, gid, FT_LOAD_NO_SCALE))
+        return false;
+    FT_GlyphSlot slot = face->glyph;
+    // n_contours == 0 means an empty glyph
+    if (slot->format == FT_GLYPH_FORMAT_OUTLINE && slot->outline.n_contours == 0)
+        return false;
+#endif
+    return true;
 }
 
 } //namespace pdf2htmlEX

--- a/src/HTMLRenderer/general.cc
+++ b/src/HTMLRenderer/general.cc
@@ -29,6 +29,10 @@
 #include "util/css_const.h"
 #include "util/encoding.h"
 
+#if ENABLE_SVG
+#include "CairoFontEngine.h"
+#endif
+
 namespace pdf2htmlEX {
 
 using std::fixed;
@@ -86,11 +90,19 @@ HTMLRenderer::HTMLRenderer(const Param & param)
             [this](double * box, bool partial) { covered_text_detector.add_char_bbox_clipped(box, partial); };
     tracer.on_non_char_drawn =
             [this](double * box) { covered_text_detector.add_non_char_bbox(box); };
+
+#if ENABLE_SVG
+    FT_Init_FreeType(&ft_lib);
+    font_engine = std::unique_ptr<CairoFontEngine>(new CairoFontEngine(ft_lib));
+#endif
 }
 
 HTMLRenderer::~HTMLRenderer()
 {
     ffw_finalize();
+#if ENABLE_SVG
+    FT_Done_FreeType(ft_lib);
+#endif
 }
 
 void HTMLRenderer::process(PDFDoc *doc)

--- a/src/HTMLTextLine.h
+++ b/src/HTMLTextLine.h
@@ -107,6 +107,7 @@ private:
      */
     void dump_chars(std::ostream & out, int begin, int len);
     void dump_char(std::ostream & out, int pos);
+    void dump_unicode(std::ostream & out, Unicode u);
 
     const Param & param;
     AllStateManager & all_manager;
@@ -128,6 +129,8 @@ private:
      */
     std::vector<int> text;
     std::vector<std::vector<Unicode> > decomposed_text;
+
+    Unicode last_output_unicode; //last unicode written to html (chars in tags excluded)
 };
 
 } // namespace pdf2htmlEX

--- a/src/util/unicode.h
+++ b/src/util/unicode.h
@@ -13,6 +13,8 @@
 
 namespace pdf2htmlEX {
 
+const Unicode zero_width_space = 0x200B;
+
 /**
  * Check whether a unicode character is illegal for the output HTML.
  * Unlike PDF readers, browsers has special treatments for such characters (normally treated as


### PR DESCRIPTION
This patch convert space-like char (usually illegal in html) in PDF to space/ZWSP in html, rather than private unicodes. Now sample in #477 can be converted perfectly.

This patch depends on `CairoFontEngine` so ENABLE_SVG should be on (if set off, will not convert at all). 

There are minor modifications to `CairoFontEngine.h|cc` which should be merged in furture update.
