### PR TITLE
[WIP] Overhaul of the inner structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,6 @@ set(CMAKE_BUILD_TYPE Release CACHE STRING "Build configuration (Debug, Release, 
 project(pdf2htmlEX)
 cmake_minimum_required(VERSION 2.6.0 FATAL_ERROR)
 
-option(ENABLE_SVG "Enable SVG support, for generating SVG background images and converting Type 3 fonts" ON)
-
 include_directories(${CMAKE_SOURCE_DIR}/src)
 
 set(PDF2HTMLEX_VERSION "0.13.6")
@@ -24,34 +22,31 @@ include_directories(${POPPLER_INCLUDE_DIRS})
 link_directories(${POPPLER_LIBRARY_DIRS})
 set(PDF2HTMLEX_LIBS ${PDF2HTMLEX_LIBS} ${POPPLER_LIBRARIES})
 
-if(ENABLE_SVG)
-    pkg_check_modules(CAIRO REQUIRED cairo>=1.10.0)
-    message("Trying to locate cairo-svg...")
-    find_path(CAIRO_SVG_INCLUDE_PATH cairo-svg.h PATHS ${CAIRO_INCLUDE_DIRS} NO_DEFAULT_PATH)
-    if(CAIRO_SVG_INCLUDE_PATH)
-        include_directories(${CAIRO_INCLUDE_DIRS})
-        link_directories(${CAIRO_LIBRARY_DIRS})
-        set(PDF2HTMLEX_LIBS ${PDF2HTMLEX_LIBS} ${CAIRO_LIBRARIES})
-        set(ENABLE_SVG 1)
-        set(CAIROOUTPUTDEV_PATH 3rdparty/poppler/git)
-        include_directories(${CAIROOUTPUTDEV_PATH})
-        set(PDF2HTMLEX_SRC ${PDF2HTMLEX_SRC}
-            ${CAIROOUTPUTDEV_PATH}/CairoFontEngine.h
-            ${CAIROOUTPUTDEV_PATH}/CairoFontEngine.cc
-            ${CAIROOUTPUTDEV_PATH}/CairoRescaleBox.h
-            ${CAIROOUTPUTDEV_PATH}/CairoRescaleBox.cc
-            ${CAIROOUTPUTDEV_PATH}/CairoOutputDev.h
-            ${CAIROOUTPUTDEV_PATH}/CairoOutputDev.cc
-        )
-    else()
-        message(FATAL_ERROR "Error: no SVG support found in Cairo")
-    endif()
-
-    find_package(Freetype REQUIRED)
-    include_directories(${FREETYPE_INCLUDE_DIRS})
-    link_directories(${FREETYPE_LIBRARY_DIRS})
-    set(PDF2HTMLEX_LIBS ${PDF2HTMLEX_LIBS} ${FREETYPE_LIBRARIES})
+pkg_check_modules(CAIRO REQUIRED cairo>=1.10.0)
+message("Trying to locate cairo-svg...")
+find_path(CAIRO_SVG_INCLUDE_PATH cairo-svg.h PATHS ${CAIRO_INCLUDE_DIRS} NO_DEFAULT_PATH)
+if(CAIRO_SVG_INCLUDE_PATH)
+    include_directories(${CAIRO_INCLUDE_DIRS})
+    link_directories(${CAIRO_LIBRARY_DIRS})
+    set(PDF2HTMLEX_LIBS ${PDF2HTMLEX_LIBS} ${CAIRO_LIBRARIES})
+    set(CAIROOUTPUTDEV_PATH 3rdparty/poppler/git)
+    include_directories(${CAIROOUTPUTDEV_PATH})
+    set(PDF2HTMLEX_SRC ${PDF2HTMLEX_SRC}
+        ${CAIROOUTPUTDEV_PATH}/CairoFontEngine.h
+        ${CAIROOUTPUTDEV_PATH}/CairoFontEngine.cc
+        ${CAIROOUTPUTDEV_PATH}/CairoRescaleBox.h
+        ${CAIROOUTPUTDEV_PATH}/CairoRescaleBox.cc
+        ${CAIROOUTPUTDEV_PATH}/CairoOutputDev.h
+        ${CAIROOUTPUTDEV_PATH}/CairoOutputDev.cc
+    )
+else()
+    message(FATAL_ERROR "Error: no SVG support found in Cairo")
 endif()
+
+find_package(Freetype REQUIRED)
+include_directories(${FREETYPE_INCLUDE_DIRS})
+link_directories(${FREETYPE_LIBRARY_DIRS})
+set(PDF2HTMLEX_LIBS ${PDF2HTMLEX_LIBS} ${FREETYPE_LIBRARIES})
 
 # fontforge starts using pkg-config 'correctly' since 2.0.0
 pkg_check_modules(FONTFORGE REQUIRED libfontforge>=2.0.0)

--- a/debian/rules
+++ b/debian/rules
@@ -2,9 +2,6 @@
 %:
 	dh $@
 
-override_dh_auto_configure:
-	dh_auto_configure -- -DENABLE_SVG=ON
-
 override_dh_auto_test:
 
 

--- a/src/BackgroundRenderer/BackgroundRenderer.cc
+++ b/src/BackgroundRenderer/BackgroundRenderer.cc
@@ -12,9 +12,7 @@
 
 #include "BackgroundRenderer.h"
 #include "SplashBackgroundRenderer.h"
-#if ENABLE_SVG
 #include "CairoBackgroundRenderer.h"
-#endif
 
 namespace pdf2htmlEX {
 
@@ -32,12 +30,10 @@ std::unique_ptr<BackgroundRenderer> BackgroundRenderer::getBackgroundRenderer(co
         return std::unique_ptr<BackgroundRenderer>(new SplashBackgroundRenderer(format, html_renderer, param));
     }
 #endif
-#if ENABLE_SVG
     if (format == "svg")
     {
         return std::unique_ptr<BackgroundRenderer>(new CairoBackgroundRenderer(html_renderer, param));
     }
-#endif
 
     return nullptr;
 }

--- a/src/BackgroundRenderer/CairoBackgroundRenderer.cc
+++ b/src/BackgroundRenderer/CairoBackgroundRenderer.cc
@@ -12,8 +12,6 @@
 
 #include "Base64Stream.h"
 
-#if ENABLE_SVG
-
 #include "CairoBackgroundRenderer.h"
 #include "SplashBackgroundRenderer.h"
 
@@ -303,6 +301,4 @@ void CairoBackgroundRenderer::setMimeData(Stream *str, Object *ref, cairo_surfac
 }
 
 } // namespace pdf2htmlEX
-
-#endif // ENABLE_SVG
 

--- a/src/BackgroundRenderer/SplashBackgroundRenderer.cc
+++ b/src/BackgroundRenderer/SplashBackgroundRenderer.cc
@@ -159,8 +159,8 @@ void SplashBackgroundRenderer::embed_image(int pageno)
             dump_image((char*)fn, xmin, ymin, xmax, ymax);
         }
 
-        double h_scale = html_renderer->text_zoom_factor() * DEFAULT_DPI / param.h_dpi;
-        double v_scale = html_renderer->text_zoom_factor() * DEFAULT_DPI / param.v_dpi;
+        double h_scale = html_renderer->zoom_factor * DEFAULT_DPI / param.h_dpi;
+        double v_scale = html_renderer->zoom_factor * DEFAULT_DPI / param.v_dpi;
 
         auto & f_page = *(html_renderer->f_curpage);
         auto & all_manager = html_renderer->all_manager;

--- a/src/DrawingTracer.h
+++ b/src/DrawingTracer.h
@@ -11,13 +11,9 @@
 #include <functional>
 
 #include <GfxState.h>
+#include <cairo.h>
 
 #include "pdf2htmlEX-config.h"
-
-#if ENABLE_SVG
-#include <cairo.h>
-#endif
-
 #include "Param.h"
 
 namespace pdf2htmlEX
@@ -70,9 +66,7 @@ private:
 
     const Param & param;
 
-#if ENABLE_SVG
     cairo_t * cairo;
-#endif
 };
 
 } /* namespace pdf2htmlEX */

--- a/src/HTMLRenderer/HTMLRenderer.h
+++ b/src/HTMLRenderer/HTMLRenderer.h
@@ -227,22 +227,10 @@ protected:
     int pageNum;
 
     double default_ctm[6];
-
-    /*
-     * The content of each page is first scaled with factor1 (>=1), then scale back with factor2(<=1)
-     *
-     * factor1 is use to multiplied with all metrics (height/width/font-size...), in order to improve accuracy
-     * factor2 is applied with css transform, and is exposed to Javascript
-     *
-     * factor1 & factor 2 are determined according to zoom and font-size-multiplier
-     *
-     */
-    double text_zoom_factor (void) const { return text_scale_factor1 * text_scale_factor2; }
-    double text_scale_factor1;
-    double text_scale_factor2;
+    double zoom_factor;
 
     // 1px on screen should be printed as print_scale()pt
-    double print_scale (void) const { return 96.0 / DEFAULT_DPI / text_zoom_factor(); }
+    double print_scale (void) const { return 96.0 / DEFAULT_DPI / zoom_factor; }
 
 
     const Param & param;
@@ -281,7 +269,8 @@ protected:
     
     // the actual tm used is `real tm in PDF` scaled by 1/draw_text_scale, 
     // so everything rendered should be multiplied by draw_text_scale
-    double draw_text_scale; 
+    // OVERHAUL TODO
+    // double draw_text_scale; 
 
     // the position of next char, in text coords
     // this is actual position (in HTML), which might be different from cur_tx/ty (in PDF)

--- a/src/HTMLRenderer/HTMLRenderer.h
+++ b/src/HTMLRenderer/HTMLRenderer.h
@@ -240,7 +240,6 @@ protected:
     ////////////////////////////////////////////////////
     // track the original (unscaled) values to determine scaling and merge lines
     // current position
-    double cur_tx, cur_ty; // real text position, in text coords
     double cur_font_size;
     // this is CTM * TextMAT in PDF
     // as we'll calculate the position of the origin separately

--- a/src/HTMLRenderer/HTMLRenderer.h
+++ b/src/HTMLRenderer/HTMLRenderer.h
@@ -256,7 +256,6 @@ protected:
     bool word_space_changed;
     bool letter_space_changed;
     bool stroke_color_changed;
-    bool clip_changed;
 
     ////////////////////////////////////////////////////
     // HTML states
@@ -294,7 +293,6 @@ protected:
         NLS_NONE,
         NLS_NEWSTATE, 
         NLS_NEWLINE,
-        NLS_NEWCLIP
     } new_line_state;
     
     // for font reencoding

--- a/src/HTMLRenderer/HTMLRenderer.h
+++ b/src/HTMLRenderer/HTMLRenderer.h
@@ -324,9 +324,7 @@ protected:
 
     // render background image
     friend class SplashBackgroundRenderer; // ugly!
-#if ENABLE_SVG
     friend class CairoBackgroundRenderer; // ugly!
-#endif
 
     std::unique_ptr<BackgroundRenderer> bg_renderer, fallback_bg_renderer;
 

--- a/src/HTMLRenderer/font.cc
+++ b/src/HTMLRenderer/font.cc
@@ -16,6 +16,7 @@
 #include <GlobalParams.h>
 #include <fofi/FoFiTrueType.h>
 #include <CharCodeToUnicode.h>
+#include <Gfx.h>
 
 #include "Param.h"
 #include "HTMLRenderer.h"
@@ -31,14 +32,11 @@
 #include "util/unicode.h"
 #include "util/css_const.h"
 
-#if ENABLE_SVG
 #include <cairo.h>
 #include <cairo-ft.h>
 #include <cairo-svg.h>
 #include "CairoFontEngine.h"
 #include "CairoOutputDev.h"
-#include <Gfx.h>
-#endif
 
 namespace pdf2htmlEX {
 
@@ -186,7 +184,6 @@ string HTMLRenderer::dump_type3_font (GfxFont * font, FontInfo & info)
 {
     assert(info.is_type3);
 
-#if ENABLE_SVG
     long long fn_id = info.id;
 
     FT_Library ft_lib;
@@ -244,7 +241,7 @@ string HTMLRenderer::dump_type3_font (GfxFont * font, FontInfo & info)
 
 #if 1
         {
-            // pain the glyph
+            // paint the glyph
             cairo_set_font_face(cr, cur_font->getFontFace());
 
             cairo_matrix_t m1, m2, m3;
@@ -364,9 +361,6 @@ string HTMLRenderer::dump_type3_font (GfxFont * font, FontInfo & info)
     ffw_close();
 
     return font_filename;
-#else
-    return "";
-#endif
 }
 
 void HTMLRenderer::embed_font(const string & filepath, GfxFont * font, FontInfo & info, bool get_metric_only)
@@ -856,7 +850,6 @@ const FontInfo * HTMLRenderer::install_font(GfxFont * font)
 
     if(new_font_info.is_type3)
     {
-#if ENABLE_SVG
         if(param.process_type3)
         {
             install_embedded_font(font, new_font_info);
@@ -865,10 +858,6 @@ const FontInfo * HTMLRenderer::install_font(GfxFont * font)
         {
             export_remote_default_font(new_fn_id);
         }
-#else
-        cerr << "Type 3 fonts are unsupported and will be rendered as Image" << endl;
-        export_remote_default_font(new_fn_id);
-#endif
         return &new_font_info;
     }
     if(font->getWMode()) {

--- a/src/HTMLRenderer/general.cc
+++ b/src/HTMLRenderer/general.cc
@@ -140,7 +140,7 @@ void HTMLRenderer::process(PDFDoc *doc)
         }
 
         doc->displayPage(this, i,
-                text_zoom_factor() * DEFAULT_DPI, text_zoom_factor() * DEFAULT_DPI,
+                zoom_factor * DEFAULT_DPI, zoom_factor * DEFAULT_DPI,
                 0,
                 (!(param.use_cropbox)),
                 true,  // crop
@@ -301,10 +301,7 @@ void HTMLRenderer::pre_process(PDFDoc * doc)
             zoom_factors.push_back((param.fit_height) / preprocessor.get_max_height());
         }
 
-        double zoom = (zoom_factors.empty() ? 1.0 : (*min_element(zoom_factors.begin(), zoom_factors.end())));
-
-        text_scale_factor1 = max<double>(zoom, param.font_size_multiplier);
-        text_scale_factor2 = zoom / text_scale_factor1;
+        zoom_factor = (zoom_factors.empty() ? 1.0 : (*min_element(zoom_factors.begin(), zoom_factors.end())));
     }
 
     // we may output utf8 characters, so always use binary

--- a/src/HTMLRenderer/state.cc
+++ b/src/HTMLRenderer/state.cc
@@ -31,13 +31,10 @@ void HTMLRenderer::updateRise(GfxState * state)
 void HTMLRenderer::updateTextPos(GfxState * state) 
 {
     text_pos_changed = true;
-    cur_tx = state->getLineX(); 
-    cur_ty = state->getLineY(); 
 }
 void HTMLRenderer::updateTextShift(GfxState * state, double shift) 
 {
     text_pos_changed = true;
-    cur_tx -= shift * 0.001 * state->getFontSize() * state->getHorizScaling(); 
 }
 void HTMLRenderer::updateFont(GfxState * state) 
 {
@@ -128,7 +125,6 @@ void HTMLRenderer::reset_state()
     cur_clip_state.ymin = 0;
     cur_clip_state.ymax = 0;
 
-    cur_tx  = cur_ty  = 0;
     draw_tx = draw_ty = 0;
 
     reset_state_change();
@@ -311,6 +307,9 @@ void HTMLRenderer::check_state_change(GfxState * state)
          */
 
         bool merged = false;
+        // OVERHAUL TODO: cur_tx/ty have been removed
+        double cur_tx = draw_tx;
+        double cur_ty = draw_ty; 
         double dx = 0;
         double dy = 0;
         if(tm_equal(old_line_state.transform_matrix, cur_line_state.transform_matrix, 4))
@@ -373,8 +372,6 @@ void HTMLRenderer::check_state_change(GfxState * state)
                 cur_text_state.vertical_align = dy;
                 set_line_state(new_line_state, NLS_NEWSTATE);
             }
-            draw_tx = cur_tx;
-            draw_ty = cur_ty;
         }
         else
         {
@@ -486,21 +483,6 @@ void HTMLRenderer::prepare_text_line(GfxState * state)
         html_text_page.open_new_line(cur_line_state);
 
         cur_text_state.vertical_align = 0;
-
-        //resync position
-        draw_ty = cur_ty;
-        draw_tx = cur_tx;
-    }
-    else
-    {
-        // align horizontal position
-        // try to merge with the last line if possible
-        double target = (cur_tx - draw_tx);
-        if(!equal(target, 0))
-        {
-            html_text_page.get_cur_line()->append_offset(target);
-            draw_tx += target;
-        }
     }
 
     if(new_line_state != NLS_NONE)

--- a/src/HTMLRenderer/text.cc
+++ b/src/HTMLRenderer/text.cc
@@ -144,9 +144,6 @@ void HTMLRenderer::drawString(GfxState * state, GooString * s)
         len -= n;
     }
 
-    cur_tx += dx;
-    cur_ty += dy;
-        
     draw_tx += dx;
     draw_ty += dy;
 }

--- a/src/HTMLRenderer/text.cc
+++ b/src/HTMLRenderer/text.cc
@@ -103,7 +103,7 @@ void HTMLRenderer::drawString(GfxState * state, GooString * s)
         {
             html_text_page.get_cur_line()->append_padding_char();
             // ignore horiz_scaling, as it has been merged into CTM
-            html_text_page.get_cur_line()->append_offset((ax * cur_font_size + cur_letter_space + cur_word_space) * draw_text_scale);
+            html_text_page.get_cur_line()->append_offset(ax * cur_font_size + cur_letter_space + cur_word_space);
         }
         else
         {
@@ -130,7 +130,7 @@ void HTMLRenderer::drawString(GfxState * state, GooString * s)
                 int space_count = (is_space ? 1 : 0) - ((uu == ' ') ? 1 : 0);
                 if(space_count != 0)
                 {
-                    html_text_page.get_cur_line()->append_offset(cur_word_space * draw_text_scale * space_count);
+                    html_text_page.get_cur_line()->append_offset(cur_word_space * space_count);
                 }
             }
         }

--- a/src/pdf2htmlEX-config.h.in
+++ b/src/pdf2htmlEX-config.h.in
@@ -11,8 +11,6 @@
 
 #include <string>
 
-#define ENABLE_SVG @ENABLE_SVG@
-
 namespace pdf2htmlEX {
 
 static const std::string PDF2HTMLEX_VERSION = "@PDF2HTMLEX_VERSION@";

--- a/src/pdf2htmlEX.cc
+++ b/src/pdf2htmlEX.cc
@@ -317,22 +317,12 @@ void check_param()
 #ifdef ENABLE_LIBJPEG
     else if (param.bg_format == "jpg") { }
 #endif
-#if ENABLE_SVG
-    else if(param.bg_format == "svg") { }
-#endif
+    else if (param.bg_format == "svg") { }
     else
     {
         cerr << "Image format not supported: " << param.bg_format << endl;
         exit(EXIT_FAILURE);
     }
-
-#if not ENABLE_SVG
-    if(param.process_type3)
-    {
-        cerr << "process-type3 is enabled, however SVG support is not built in this version of pdf2htmlEX." << endl;
-        exit(EXIT_FAILURE);
-    }
-#endif
 
     if((param.font_format == "ttf") && (param.external_hint_tool == ""))
     {

--- a/src/pdf2htmlEX.cc
+++ b/src/pdf2htmlEX.cc
@@ -17,17 +17,14 @@
 
 #include <poppler-config.h>
 #include <goo/GooString.h>
-
 #include <Object.h>
 #include <PDFDoc.h>
 #include <PDFDocFactory.h>
 #include <GlobalParams.h>
 
-#include "pdf2htmlEX-config.h"
-
-#if ENABLE_SVG
 #include <cairo.h>
-#endif
+
+#include "pdf2htmlEX-config.h"
 
 #include "ArgParser.h"
 #include "Param.h"
@@ -60,9 +57,7 @@ void show_version_and_exit(const char * dummy = nullptr)
     cerr << "Libraries: " << endl;
     cerr << "  poppler " << POPPLER_VERSION << endl;
     cerr << "  libfontforge " << ffw_get_version() << endl;
-#if ENABLE_SVG
     cerr << "  cairo " << cairo_version_string() << endl;
-#endif
     cerr << "Default data-dir: " << param.data_dir << endl;
     cerr << "Supported image format:";
 #ifdef ENABLE_LIBPNG
@@ -71,9 +66,7 @@ void show_version_and_exit(const char * dummy = nullptr)
 #ifdef ENABLE_LIBJPEG
     cerr << " jpg";
 #endif
-#if ENABLE_SVG
     cerr << " svg";
-#endif
     cerr << endl;
 
     // TODO: define constants

--- a/src/text/TextChar.h
+++ b/src/text/TextChar.h
@@ -1,0 +1,28 @@
+// CharNode: holds a char
+// Copyright (C) 2015 Lu Wang <coolwanglu@gmail.com>
+
+#ifndef CHARNODE_H__
+#define CHARNODE_H__
+
+#include <cairo.h>
+
+namespace pdf2htmlEX {
+
+struct CharNode
+{
+    // the bounding box for the glyph, in text coordinates
+    cairo_rectangle_t bbox; 
+
+    // the location and shifts of the origin/base, in text coordinates
+    double x, y, dx, dy; 
+
+    int order_number;
+
+    // unicode's?
+    // original char code?
+    // font pointer?
+};
+
+} // namespace pdf2htmlEX
+
+#endif // CHARNODE_H__

--- a/src/text/TextNode.h
+++ b/src/text/TextNode.h
@@ -1,0 +1,31 @@
+// Basic node for the linked lists
+// Copyright (C) 2015 Lu Wang <coolwanglu@gmail.com>
+
+#ifndef BASICNODE_H__
+#define BASICNODE_H__
+
+#include <boost/intrusive/list.hpp>
+
+namespace pdf2htmlEX {
+
+enum class NodeType : char
+{
+    BasicNode
+};
+
+struct BasicListTag; // for boost::intrusive::list
+
+/*
+ * BasicNode is the common parent for all the nodes
+ */
+struct BasicNode
+    : boost::intrusive::list_base_hook< tag<BasicListTag> >
+{
+    NodeType get_type () const { return type; }
+private:
+    NodeType type;
+};
+
+} // namespace pdf2htmlEX
+
+#endif //BASICNODE_H__

--- a/src/text/TextPage.h
+++ b/src/text/TextPage.h
@@ -1,0 +1,32 @@
+// TextPage: a list of segments
+// Copyright (C) 2015 Lu Wang <coolwanglu@gmail.com>
+
+#ifndef TEXTPAGE_H__
+#define TEXTPAGE_H__
+
+#include "TextSegment.h"
+
+namespace pdf2htmlEX {
+
+struct TextPage 
+{
+    ~TextPage() { segments.clear_and_dispose([](void *p){ delete p; }); }
+
+    const double * get_default_ctm () const { return default_ctm; }
+
+    using iterator = TextSegmentList::iterator;
+    iterator begin() { return segments.begin(); }
+    iterator end() { return segments.end(); }
+    void push_back(TextSegment& segment) { segments.push_back(segment); }
+
+private:
+    TextSegmentList segments;
+
+    int num;
+    double width, height;
+    double default_ctm[6];
+};
+
+}
+
+#endif //TEXTPAGE_H__

--- a/src/text/TextPageBuilder.cc
+++ b/src/text/TextPageBuilder.cc
@@ -1,0 +1,280 @@
+/*
+ * TextPageBuilder.cc
+ * Copyright (C) 2015 Lu Wang <coolwanglu@gmail.com>
+ */
+
+#include <cstring>
+
+#include "TextPageBuilder.h"
+
+namespace pdf2htmlEX {
+
+void TextPageBuilder::setDefaultCTM(double * ctm)
+{
+    memcpy(page.default_ctm, ctm, sizeof(page.default_ctm));
+}
+
+void TextPageBuilder::startPage(int pageNum, GfxState *state, XRef * xref)
+{
+    page.num = pageNum;
+    page.width = state->getPageWidth();
+    page.height = state->getPageHeight();
+}
+
+void TextPageBuilder::endPage()
+{
+    end_segment();
+    // run passes
+}
+
+void TextPageBuilder::restoreState(GfxState * state)
+{
+    updateAll(state);
+}
+
+void TextPageBuilder::saveState(GfxState * state)
+{
+}
+
+void TextPageBuilder::updateAll(GfxState * state) 
+{ 
+    new_segment(state, true);
+    updateTextPos(state);
+}
+void TextPageBuilder::updateRise(GfxState * state)
+{
+    new_word(state);
+}
+void TextPageBuilder::updateTextPos(GfxState * state) 
+{
+    new_word(state);
+    cur_tx = state->getLineX(); 
+    cur_ty = state->getLineY(); 
+}
+void TextPageBuilder::updateTextShift(GfxState * state, double shift) 
+{
+    new_word(state);
+    cur_tx -= shift * 0.001 * state->getFontSize() * state->getHorizScaling();
+}
+void TextPageBuilder::updateFont(GfxState * state) 
+{
+    new_segment(state);
+}
+void TextPageBuilder::updateCTM(GfxState * state, double m11, double m12, double m21, double m22, double m31, double m32) 
+{
+    new_segment(state);
+    //tracer.update_ctm(state, m11, m12, m21, m22, m31, m32);
+}
+void TextPageBuilder::updateTextMat(GfxState * state) 
+{
+    new_segment(state);
+}
+void TextPageBuilder::updateHorizScaling(GfxState * state)
+{
+    new_segment(state);
+}
+void TextPageBuilder::updateCharSpace(GfxState * state)
+{
+    new_segment(state);
+}
+void TextPageBuilder::updateWordSpace(GfxState * state)
+{
+    new_segment(state);
+}
+void TextPageBuilder::updateRender(GfxState * state) 
+{
+    new_segment(state);
+}
+void TextPageBuilder::updateFillColorSpace(GfxState * state) 
+{
+    new_segment(state);
+}
+void TextPageBuilder::updateStrokeColorSpace(GfxState * state) 
+{
+    new_segment(state);
+}
+void TextPageBuilder::updateFillColor(GfxState * state) 
+{
+    new_segment(state);
+}
+void TextPageBuilder::updateStrokeColor(GfxState * state) 
+{
+    new_segment(state);
+}
+void TextPageBuilder::clip(GfxState * state)
+{
+    //tracer.clip(state);
+}
+void TextPageBuilder::eoClip(GfxState * state)
+{
+    //tracer.clip(state, true);
+}
+void TextPageBuilder::clipToStrokePath(GfxState * state)
+{
+    //tracer.clip_to_stroke_path(state);
+}
+
+void TextPageBuilder::drawString(GfxState * state, GooString * s)
+{
+    if(s->getLength() == 0)
+        return;
+
+    auto font = state->getFont();
+    double cur_letter_space = state->getCharSpace();
+    double cur_word_space   = state->getWordSpace();
+    double cur_horiz_scaling = state->getHorizScaling();
+
+    // Writing mode fonts are rendered as images
+    // I don't find a way to display writing mode fonts in HTML except for one div for each character, which is too costly
+    if( (font == nullptr) 
+        || (font->getWMode())
+        || ((font->getType() == fontType3) && (!param.process_type3))
+      )
+    {
+        return;
+    }
+
+    // Now ready to output
+    // get the unicodes
+    char *p = s->getCString();
+    int len = s->getLength();
+
+    //accumulated displacement of chars in this string, in text object space
+    double dx = 0;
+    double dy = 0;
+    //displacement of current char, in text object space, including letter space but not word space.
+    double ddx, ddy;
+    //advance of current char, in glyph space
+    double ax, ay;
+    //origin of current char, in glyph space
+    double ox, oy;
+
+    int uLen;
+
+    CharCode code;
+    Unicode *u = nullptr;
+
+    while (len > 0) 
+    {
+        auto n = font->getNextChar(p, len, &code, &u, &uLen, &ax, &ay, &ox, &oy);
+
+        if(!(equal(ox, 0) && equal(oy, 0)))
+        {
+            log_once("TODO: non-zero origins, please file an issue on GitHub!");
+        }
+        ddx = ax * cur_font_size + cur_letter_space;
+        ddy = ay * cur_font_size;
+        tracer.draw_char(state, dx, dy, ax, ay);
+
+        bool is_space = false;
+        if (n == 1 && *p == ' ') 
+        {
+            /*
+             * This is by standard
+             * however some PDF will use ' ' as a normal encoding slot
+             * such that it will be mapped to other unicodes
+             * In that case, when space_as_offset is on, we will simply ignore that character...
+             *
+             * Checking mapped unicode may or may not work
+             * There are always ugly PDF files with no useful info at all.
+             */
+            is_space = true;
+        }
+        
+        if(is_space && (param.space_as_offset))
+        {
+            html_text_page.get_cur_line()->append_padding_char();
+            // ignore horiz_scaling, as it has been merged into CTM
+            html_text_page.get_cur_line()->append_offset(ax * cur_font_size + cur_letter_space + cur_word_space);
+        }
+        else
+        {
+            if((param.decompose_ligature) && (uLen > 1) && none_of(u, u+uLen, is_illegal_unicode))
+            {
+                html_text_page.get_cur_line()->append_unicodes(u, uLen, ddx);
+            }
+            else
+            {
+                Unicode uu;
+                if(cur_text_state.font_info->use_tounicode)
+                {
+                    uu = check_unicode(u, uLen, code, font);
+                }
+                else
+                {
+                    uu = unicode_from_font(code, font);
+                }
+                html_text_page.get_cur_line()->append_unicodes(&uu, 1, ddx);
+                /*
+                 * In PDF, word_space is appended if (n == 1 and *p = ' ')
+                 * but in HTML, word_space is appended if (uu == ' ')
+                 */
+                int space_count = (is_space ? 1 : 0) - ((uu == ' ') ? 1 : 0);
+                if(space_count != 0)
+                {
+                    html_text_page.get_cur_line()->append_offset(cur_word_space * space_count);
+                }
+            }
+        }
+
+        dx += ddx * cur_horiz_scaling;
+        dy += ddy;
+        if (is_space)
+            dx += cur_word_space * cur_horiz_scaling;
+
+        p += n;
+        len -= n;
+    }
+
+    draw_tx += dx;
+    draw_ty += dy;
+}
+
+bool TextPageBuilder::new_segment(GfxState * state, bool copy_state)
+{
+    if(!cur_segment)
+    {
+        cur_segment = new TextSegment();
+        copy_state(state);
+        return true;
+    }
+
+    if (copy_state)
+        copy_state(state);
+    return false;
+}
+
+void TextPageBuilder::end_segment()
+{
+    end_word();
+    if(cur_segment && !cur_segment->empty())
+    {
+        page.push_back(*cur_segment);
+        cur_segment = nullptr;
+    }
+}
+
+void TextPageBuilder::begin_word(GfxState * state)
+{
+    if(!cur_word)
+        cur_word = new TextWord();
+}
+
+void TextPageBuilder::end_word()
+{
+    if(cur_word && !cur_word->empty())
+    {
+        cur_segment->push_back(cur_word);
+        cur_word = nullptr;
+    }
+}
+
+void TextPageBuilder::copy_state(GfxState * state)
+{
+    auto & style = cur_segment->style;
+    // TODO
+
+}
+
+
+} //namespace pdf2htmlEX

--- a/src/text/TextPageBuilder.h
+++ b/src/text/TextPageBuilder.h
@@ -1,0 +1,152 @@
+/*
+ * TextPageBuilder.h
+ *
+ * Copyright (C) 2015 Lu Wang <coolwanglu@gmail.com>
+ */
+
+#ifndef TEXTPAGEBUILDER_H__
+#define TEXTPAGEBUILDER_H__
+
+#include <OutputDev.h>
+#include <GfxState.h>
+#include <Stream.h>
+#include <PDFDoc.h>
+
+namespace pdf2htmlEX {
+
+// Dump PDF instruction into nodes;
+struct TextPageBuilder : OutputDev
+{
+    ////////////////////////////////////////////////////
+    // OutputDev interface
+    ////////////////////////////////////////////////////
+    
+    // Does this device use upside-down coordinates?
+    // (Upside-down means (0,0) is the top left corner of the page.)
+    virtual GBool upsideDown() { return gFalse; }
+
+    // Does this device use drawChar() or drawString()?
+    virtual GBool useDrawChar() { return gFalse; }
+
+    // Does this device use functionShadedFill(), axialShadedFill(), and
+    // radialShadedFill()?  If this returns false, these shaded fills
+    // will be reduced to a series of other drawing operations.
+    virtual GBool useShadedFills(int type) { return (type == 2) ? gTrue: gFalse; }
+
+    // Does this device use beginType3Char/endType3Char?  Otherwise,
+    // text in Type 3 fonts will be drawn with drawChar/drawString.
+    virtual GBool interpretType3Chars() { return gFalse; }
+
+    // Does this device need non-text content?
+    virtual GBool needNonText() { return gTrue; }
+
+    // Does this device need to clip pages to the crop box even when the
+    // box is the crop box?
+    virtual GBool needClipToCropBox() { return gTrue; }
+
+    virtual void setDefaultCTM(double *ctm);
+
+    virtual void startPage(int pageNum, GfxState *state, XRef * xref);
+    virtual void endPage();
+
+    virtual void restoreState(GfxState * state);
+    virtual void saveState(GfxState *state);
+
+    virtual void updateAll(GfxState * state);
+
+    virtual void updateRise(GfxState * state);
+    virtual void updateTextPos(GfxState * state);
+    virtual void updateTextShift(GfxState * state, double shift);
+
+    virtual void updateFont(GfxState * state);
+    virtual void updateCTM(GfxState * state, double m11, double m12, double m21, double m22, double m31, double m32);
+    virtual void updateTextMat(GfxState * state);
+    virtual void updateHorizScaling(GfxState * state);
+
+    virtual void updateCharSpace(GfxState * state);
+    virtual void updateWordSpace(GfxState * state);
+
+    virtual void updateRender(GfxState * state);
+
+    virtual void updateFillColorSpace(GfxState * state);
+    virtual void updateStrokeColorSpace(GfxState * state);
+    virtual void updateFillColor(GfxState * state);
+    virtual void updateStrokeColor(GfxState * state);
+
+
+    /*
+     * Rendering
+     */
+
+    virtual void clip(GfxState * state);
+    virtual void eoClip(GfxState * state);
+    virtual void clipToStrokePath(GfxState * state);
+    
+    virtual void drawString(GfxState * state, GooString * s);
+
+    virtual void drawImage(GfxState * state, 
+                           Object * ref, 
+                           Stream * str, 
+                           int width, 
+                           int height, 
+                           GfxImageColorMap * colorMap, 
+                           GBool interpolate, 
+                           int *maskColors, 
+                           GBool inlineImg);
+
+    virtual void drawSoftMaskedImage(GfxState *state, 
+                                     Object *ref, 
+                                     Stream *str,
+                                     int width, 
+                                     int height,
+                                     GfxImageColorMap *colorMap,
+                                     GBool interpolate,
+                                     Stream *maskStr,
+                                     int maskWidth, 
+                                     int maskHeight,
+                                     GfxImageColorMap *maskColorMap,
+                                     GBool maskInterpolate);
+
+    virtual void stroke(GfxState *state); 
+    virtual void fill(GfxState *state);
+    virtual void eoFill(GfxState *state);
+    virtual GBool axialShadedFill(GfxState *state, GfxAxialShading *shading, double tMin, double tMax);
+
+    TextPage& get_page () { return page; }
+
+private:
+    // add a new empty segment
+    // the old one may be re-used if empty
+    // if copy_state if false and an old segment is used, we do not copy the states
+    // return if a new segment is created
+    bool begin_segment(GfxState * state, bool copy_state = false);
+    void end_segment();
+    bool new_segment(GfxState * state, bool copy_state = false) { 
+        end_segment(); 
+        return begin_segment(state, copy_state);
+    }
+
+    void begin_word(GfxState * state);
+    void end_word();
+    void new_word(GfxState * state) { 
+        end_word(); 
+        begin_word(state); 
+    }
+
+    // copy GfxState to cur_segment.style
+    void copy_state(GfxState * state);
+
+    PDFDoc * cur_doc;
+    int pageNum;
+
+    TextWord * cur_word = nullptr;
+    TextSegment * cur_segment = nullptr;
+
+    TextPage page;
+};
+
+
+} //namespace pdf2htmlEX 
+
+
+#endif // TEXTPAGEBUILDER_H__

--- a/src/text/TextSegment.h
+++ b/src/text/TextSegment.h
@@ -1,0 +1,40 @@
+// TextSegment: a list of WordNode's on the same horizontal line
+// Copyright (C) 2015 Lu Wang <coolwanglu@gmail.com>
+
+#ifndef TEXTSEGMENT_H__
+#define TEXTSEGMENT_H__
+
+#include <boost/intrusive/list.hpp>
+
+#include "TextWord.h"
+#include "TextStyle.h"
+
+namespace pdf2htmlEX {
+
+// for boost::intrusive::list
+struct TextSegmentListTag;
+using TextSegmentBaseHook = boost::intrusive::list_base_hook< tag<SegmentListTag> >;
+
+struct TextSegment : TextSegmentBaseHook
+{
+    ~TextSegment() { words.clear_and_dispose([](void *p){ delete p; }); }
+
+    using iterator = TextWordList::iterator;
+    iterator begin() { return words.begin(); }
+    iterator end() { return words.end(); }
+    bool empty() const { return words.empty();
+
+private:
+    TextStyle style;
+    TextWordList words;
+};
+
+using TextSegmentList = boost::intrusive::list< 
+    TextSegment, 
+    TextSegmentBaseHook,
+    boost::intrusive::constant_time_size<false> 
+>;
+
+}
+
+#endif //TEXTSEGMENT_H__

--- a/src/text/TextStyle.h
+++ b/src/text/TextStyle.h
@@ -1,0 +1,28 @@
+// StyleNode.h: represents styles for text
+// Copyright (C) 2015 Lu Wang <coolwanglu@gmail.com>
+#ifndef TEXTSTYLE_H__
+#define TEXTSTYLE_H__
+
+#include <cairo.h>
+
+
+namespace pdf2htmlEX {
+ 
+struct TextStyle
+{
+    // combination of CTM, TextMatrix, font_size, HorizontalScaling, rise
+    cairo_matrix_t matrix;
+
+    // matrix is that (combined) matrix in PDF scaled by 1/font_size
+    // which is usually used for canonicalization/optimization
+    double font_size;
+
+    Color fill_color;
+    Color stroke_color;
+    double letter_space;
+    double word_space;
+};
+
+} // namespace pdf2htmlEX 
+
+#endif // TEXTSTYLE_H__

--- a/src/text/TextWord.h
+++ b/src/text/TextWord.h
@@ -1,0 +1,36 @@
+// TextWord: a horizontal piece of consective characters and shifts, sharing the same styles
+// Copyright (C) 2015 Lu Wang <coolwanglu@gmail.com>
+
+#ifndef TextWord_H__
+#define TextWord_H__
+
+#include <vector>
+
+#include <boost/intrusive/list.hpp>
+
+#include "TextChar.h"
+
+namespace pdf2htmlEX {
+
+// for boost::intrusive::list
+struct TextWordListTag;
+using TextWordBaseHook = boost::intrusive::list_base_hook< tag<TextWordListTag> >
+
+struct TextWord : TextWordBaseHook
+{
+private:
+    std::vector<CharNode> chars;
+    // shift of text origin after this word and before the next word
+    double shift_after_x = 0.0;
+    double shift_after_y = 0.0;
+};
+
+using TextWordList = boost::intrusive::list< 
+    TextWord, 
+    TextWordBaseHook,
+    boost::intrusive::constant_time_size<false> 
+>;
+
+}
+
+#endif //TextWord_H__


### PR DESCRIPTION
This is (updating) snapshot of the current progress for the overhaul.

A few implementations are referred:
- `TextOutputDev` in poppler
- Tex
- llvm


Please review the files in `text/`, the idea is to store the text, shifts and styles in a more structural way, for the ease of debugging and further development.
The API is far from finished, but the overall framework is likely to be stable.

`TextPageBuilder` is supposed to be a minimal PDF-to-nodes converter, and _any_ further features will be implemented as a separate pass over the nodes. But if it turns out to be too slow in the future, we may optimize it when necessary.

Another things is, `boost::intrusive` is used for now. While I do not like to introduce new dependencies, this is a header-only library, which should be fairly easy to be included in the source tree if necessary.

@duanyao I hope that the new structure makes sense to you. For `--correct-text-visibility`, we may add additional fields for `TextChar` and process clips and images in `TextPageBuilder`. Or, we may add new types of Nodes and make a separate pass for this. All hidden characters should be removed from the structure, and we may collect the indices (indices are stored for each `TextChar`) for `BackgroundRenderers`. What do you think about it?


Please let me know if you have any comments.




### Possible passes over the data structure
- Detect and mark all the characters that are outside (or partial) the clip region, or covered (or partial) by images.
- Convert all characters with empty glyphs into offsets.
- Merge all consective offsets.
- Normalized all the matrices and sizes
- Group consective characters with same styles & matrices into words
  - A word should not contain any offset
- Group words with same styles & matrices into segments
- Group segments with same matrices into lines (or maybe paragraphs?)
- Output