### PR TITLE
Fix cloning of loading_indicator

### DIFF
--- a/share/pdf2htmlEX.js.in
+++ b/share/pdf2htmlEX.js.in
@@ -362,7 +362,7 @@ Viewer.prototype = {
       this.pages_loading[idx] = true;       // set semaphore
 
       // add a copy of the loading indicator
-      var new_loading_indicator = this.loading_indicator.cloneNode();
+      var new_loading_indicator = this.loading_indicator.cloneNode(true);
       new_loading_indicator.classList.add('active');
       cur_page_ele.appendChild(new_loading_indicator);
 


### PR DESCRIPTION
This [line](https://github.com/coolwanglu/pdf2htmlEX/blob/master/share/pdf2htmlEX.js.in#L365) `var new_loading_indicator = this.loading_indicator.cloneNode();` is just cloning the parent div and not cloning the child `image` element, resulting in loading image is not being displayed while lazy loading of pages. The `cloneNode()` needs to have boolean `true` param in order to fix this issue: `this.loading_indicator.cloneNode(true)`