### PR TITLE
Another bug fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Michele Redolfi <michele@tecnicaict.com>
 Mick Giles <mick@mickgiles.com>
 Ryan Morlok <ryan.morlok@morlok.com>
 Wanmin Liu <wanminliu@gmail.com>
+Aamir Adnan <s33k.n.d3str0y@gmail.com>
 
 Packagers:
 Arthur Titeica <arthur.titeica@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@ pdf2htmlEX is created and maintained by
 Lu Wang <coolwanglu@gmail.com>
 
 Contributors: (alphabetical order)
+Aamir Adnan <s33k.n.d3str0y@gmail.com>
 Chris Cinelli <chris@allestelle.com>
 Daniel Bonniot de Ruisselet <dbonniot@chemaxon.com>
 Deepak <iapain@gmail.com>
@@ -18,7 +19,6 @@ Michele Redolfi <michele@tecnicaict.com>
 Mick Giles <mick@mickgiles.com>
 Ryan Morlok <ryan.morlok@morlok.com>
 Wanmin Liu <wanminliu@gmail.com>
-Aamir Adnan <s33k.n.d3str0y@gmail.com>
 
 Packagers:
 Arthur Titeica <arthur.titeica@gmail.com>

--- a/share/pdf2htmlEX.js.in
+++ b/share/pdf2htmlEX.js.in
@@ -361,10 +361,13 @@ Viewer.prototype = {
     if (url) {
       this.pages_loading[idx] = true;       // set semaphore
 
-      // add a copy of the loading indicator
-      var new_loading_indicator = this.loading_indicator.cloneNode();
-      new_loading_indicator.classList.add('active');
-      cur_page_ele.appendChild(new_loading_indicator);
+      // add a copy of the loading indicator if not already present
+      var new_loading_indicator = cur_page_ele.getElementsByClassName(this.config['loading_indicator_cls'])[0];
+      if (typeof new_loading_indicator === 'undefined'){
+        new_loading_indicator = this.loading_indicator.cloneNode(true);
+        new_loading_indicator.classList.add('active');
+        cur_page_ele.appendChild(new_loading_indicator);
+      }
 
       // load data
       {


### PR DESCRIPTION
Loading indicator was being cloned multiple times if `xhr` request fails for some reason. This pull request makes sure that it is only cloned into page container if not already cloned. Added my self into contributors.

Kind Regards!