### PR TITLE
fix issue when compile windows version

### DIFF
--- a/src/util/mingw.h
+++ b/src/util/mingw.h
@@ -14,6 +14,7 @@
 
 char *mkdtemp(char *temp);
 
+#include <direct.h>
 #define mkdir(A, B) _mkdir(A)
 #define stat _stat
 


### PR DESCRIPTION
fix issue: '_mkdir' was not declared in this scope

```
pdf2htmlEX-0.13.6/src/util/path.cc: In function 'void pdf2htmlEX::create_directories(const string&)':
pdf2htmlEX-0.13.6/src/util/mingw.h:17:29: error: '_mkdir' was not declared in this scope
 #define mkdir(A, B) _mkdir(A)
```
