### PR TITLE
added parameter --ignore-partial-clipping

### DIFF
--- a/src/DrawingTracer.cc
+++ b/src/DrawingTracer.cc
@@ -304,7 +304,7 @@ void DrawingTracer::draw_char_bbox(GfxState * state, double * bbox)
     if (cairo_in_clip(cairo, bbox[0], bbox[3]))
         ++pt_in;
 
-    if (pt_in == 0)
+    if (pt_in == 0 || param.ignore_partial_clipping)
     {
         transform_bbox_by_ctm(bbox);
         if(on_char_clipped)

--- a/src/Param.h
+++ b/src/Param.h
@@ -40,6 +40,7 @@ struct Param
     int process_annotation;
     int process_form;
     int correct_text_visibility;
+    int ignore_partial_clipping;
     int printing;
     int fallback;
     int tmp_file_size_limit;

--- a/src/pdf2htmlEX.cc
+++ b/src/pdf2htmlEX.cc
@@ -182,6 +182,7 @@ void parse_options (int argc, char **argv)
         .add("tounicode", &param.tounicode, 0, "how to handle ToUnicode CMaps (0=auto, 1=force, -1=ignore)")
         .add("optimize-text", &param.optimize_text, 0, "try to reduce the number of HTML elements used for text")
         .add("correct-text-visibility", &param.correct_text_visibility, 0, "try to detect texts covered by other graphics and properly arrange them")
+        .add("ignore-partial-clipping", &param.ignore_partial_clipping, 0, "when text visibility correction is enabled, ignore partially clipped char bounding boxes")
 
         // background image
         .add("bg-format", &param.bg_format, "png", "specify background image format")
@@ -341,6 +342,11 @@ void check_param()
     {
         cerr << "Warning: --svg-embed-bitmap is forced on because --embed-image is on, or the dumped bitmaps can't be loaded." << endl;
         param.svg_embed_bitmap = 1;
+    }
+
+    if (!param.correct_text_visibility && param.ignore_partial_clipping)
+    {
+        cerr << "Warning: parameter --ignore-partial-clipping has no effect if --correct-text-visibility is not enabled." << endl;
     }
 }
 


### PR DESCRIPTION
I'm a big fan of the --correct-text-visibility flag, but I have come across several documents that break horribly when the parameter is set to 1.

I looked at the various member functions of the DrawingTracer class and found that all errors I was examining originated in DrawingTracer::draw_char_bbox, and only when partial clipping was identified.

The sample document for --correct-text-visibility renders fine without partial clipping detection and disabling it leads to much more accurate outputs for the documents I've tested (which unfortunately I can't share).

I have no doubt that handling partial clipping works perfectly on many documents I haven't seen, so I added a new parameter that is off by default and which ignores partial clipping only when --ignore-partial-clipping is set to 1.

I'm not claiming that a toggle is the best solution to the partial clipping issue as it stands, but I think it's worth flagging it as an issue as it leads to broken layouts with zigzag shapes and scrambled text, enough to make users give up on --correct-text-visibility, which would be a huge shame!