### PR TITLE
enable pipe processing

### DIFF
--- a/src/Param.h
+++ b/src/Param.h
@@ -77,6 +77,7 @@ struct Param
     std::string data_dir;
     std::string poppler_data_dir;
     std::string tmp_dir;
+    int quiet;
     int debug;
     int proof;
 

--- a/src/Preprocessor.cc
+++ b/src/Preprocessor.cc
@@ -45,7 +45,8 @@ void Preprocessor::process(PDFDoc * doc)
     int page_count = (param.last_page - param.first_page + 1);
     for(int i = param.first_page; i <= param.last_page ; ++i) 
     {
-        cerr << "Preprocessing: " << (i-param.first_page) << "/" << page_count << '\r' << flush;
+        if (!param.quiet)
+            cerr << "Preprocessing: " << (i-param.first_page) << "/" << page_count << '\r' << flush;
 
         doc->displayPage(this, i, DEFAULT_DPI, DEFAULT_DPI,
                 0, 
@@ -54,9 +55,10 @@ void Preprocessor::process(PDFDoc * doc)
                 false, // printing
                 nullptr, nullptr, nullptr, nullptr);
     }
-    if(page_count >= 0)
+    if (!param.quiet && page_count >= 0)
         cerr << "Preprocessing: " << page_count << "/" << page_count;
-    cerr << endl;
+    if (!param.quiet)
+        cerr << endl;
 }
 
 void Preprocessor::drawChar(GfxState *state, double x, double y,

--- a/src/pdf2htmlEX.cc
+++ b/src/pdf2htmlEX.cc
@@ -199,6 +199,7 @@ void parse_options (int argc, char **argv)
         .add("tmp-dir", &param.tmp_dir, param.tmp_dir, "specify the location of temporary directory.")
         .add("data-dir", &param.data_dir, param.data_dir, "specify data directory")
         .add("poppler-data-dir", &param.poppler_data_dir, param.poppler_data_dir, "specify poppler data directory")
+        .add("quiet", &param.quiet, 0, "do no print processing info")
         .add("debug", &param.debug, 0, "print debugging information")
         .add("proof", &param.proof, 0, "texts are drawn on both text layer and background for proof.")
 


### PR DESCRIPTION
This change implements printing of resulting html to stdout instead of writing it to file by specifying '-' (dash) as output filename. Using this, it is possible to pipe pdf documents trough pdf2htmlEX like this:

`cat file.pdf | pdf2htmlEX fd://0 - >file.html`

Along with that --quiet option has been added, to avoid unnecessary processing info printing while in pipe mode.