### PR TITLE
enable pipe processing

### DIFF
--- a/src/HTMLRenderer/general.cc
+++ b/src/HTMLRenderer/general.cc
@@ -124,7 +124,9 @@ void HTMLRenderer::process(PDFDoc *doc)
             break;
         }
 
-        cerr << "Working: " << (i-param.first_page) << "/" << page_count << '\r' << flush;
+        if (!param.quiet) {
+            cerr << "Working: " << (i-param.first_page) << "/" << page_count << '\r' << flush;
+        }
 
         if(param.split_pages)
         {
@@ -153,9 +155,10 @@ void HTMLRenderer::process(PDFDoc *doc)
             f_curpage = nullptr;
         }
     }
-    if(page_count >= 0)
+    if (!param.quiet && page_count >= 0)
         cerr << "Working: " << page_count << "/" << page_count;
-    cerr << endl;
+    if (!param.quiet)
+        cerr << endl;
 
     ////////////////////////
     // Process Outline
@@ -167,7 +170,8 @@ void HTMLRenderer::process(PDFDoc *doc)
     bg_renderer = nullptr;
     fallback_bg_renderer = nullptr;
 
-    cerr << endl;
+    if (!param.quiet)
+       cerr << endl;
 }
 
 void HTMLRenderer::setDefaultCTM(double *ctm)
@@ -394,14 +398,21 @@ void HTMLRenderer::post_process(void)
     f_css.fs.close();
 
     // build the main HTML file
-    ofstream output;
-    {
-        auto fn = str_fmt("%s/%s", param.dest_dir.c_str(), param.output_filename.c_str());
-        output.open((char*)fn, ofstream::binary);
-        if(!output)
-            throw string("Cannot open ") + (char*)fn + " for writing";
-        set_stream_flags(output);
+    std::ofstream foutput;
+    std::streambuf *output_buf;
+    if(param.output_filename == "-") {
+        output_buf = std::cout.rdbuf();
     }
+    else {
+        auto fn = str_fmt("%s/%s", param.dest_dir.c_str(), param.output_filename.c_str());
+        foutput.open((char*)fn, ofstream::binary);
+        if(!foutput)
+            throw string("Cannot open ") + (char*)fn + " for writing";
+        set_stream_flags(foutput);
+
+        output_buf = foutput.rdbuf();
+    }
+    std::ostream output(output_buf);
 
     // apply manifest
     ifstream manifest_fin((char*)str_fmt("%s/%s", param.data_dir.c_str(), MANIFEST_FILENAME.c_str()), ifstream::binary);

--- a/src/Param.h
+++ b/src/Param.h
@@ -77,6 +77,7 @@ struct Param
     std::string data_dir;
     std::string poppler_data_dir;
     std::string tmp_dir;
+    int quiet;
     int debug;
     int proof;
 

--- a/src/Preprocessor.cc
+++ b/src/Preprocessor.cc
@@ -45,7 +45,8 @@ void Preprocessor::process(PDFDoc * doc)
     int page_count = (param.last_page - param.first_page + 1);
     for(int i = param.first_page; i <= param.last_page ; ++i) 
     {
-        cerr << "Preprocessing: " << (i-param.first_page) << "/" << page_count << '\r' << flush;
+        if (!param.quiet)
+            cerr << "Preprocessing: " << (i-param.first_page) << "/" << page_count << '\r' << flush;
 
         doc->displayPage(this, i, DEFAULT_DPI, DEFAULT_DPI,
                 0, 
@@ -54,9 +55,10 @@ void Preprocessor::process(PDFDoc * doc)
                 false, // printing
                 nullptr, nullptr, nullptr, nullptr);
     }
-    if(page_count >= 0)
+    if (!param.quiet && page_count >= 0)
         cerr << "Preprocessing: " << page_count << "/" << page_count;
-    cerr << endl;
+    if (!param.quiet)
+        cerr << endl;
 }
 
 void Preprocessor::drawChar(GfxState *state, double x, double y,

--- a/src/pdf2htmlEX.cc
+++ b/src/pdf2htmlEX.cc
@@ -334,6 +334,13 @@ void check_param()
     }
 #endif
 
+    if (param.output_filename == "-" &&
+           (!param.embed_css || !param.embed_font || !param.embed_image || !param.embed_javascript
+               || !param.embed_outline || !param.embed_external_font)) {
+        cerr << "output redirected to STDOUT, but some html parts set to be not embededed." << endl;
+        exit(EXIT_FAILURE);
+    }
+
     if((param.font_format == "ttf") && (param.external_hint_tool == ""))
     {
         cerr << "Warning: No hint tool is specified for truetype fonts, the result may be rendered poorly in some circumstances." << endl;

--- a/src/pdf2htmlEX.cc
+++ b/src/pdf2htmlEX.cc
@@ -199,6 +199,7 @@ void parse_options (int argc, char **argv)
         .add("tmp-dir", &param.tmp_dir, param.tmp_dir, "specify the location of temporary directory.")
         .add("data-dir", &param.data_dir, param.data_dir, "specify data directory")
         .add("poppler-data-dir", &param.poppler_data_dir, param.poppler_data_dir, "specify poppler data directory")
+        .add("quiet", &param.quiet, 0, "do no print processing info")
         .add("debug", &param.debug, 0, "print debugging information")
         .add("proof", &param.proof, 0, "texts are drawn on both text layer and background for proof.")
 


### PR DESCRIPTION


This change implements printing of resulting html to STDOUT instead of writing it to file by specifying '-' (dash) as output filename. Using this, it is possible to pipe pdf documents trough pdf2htmlEX like this:

`cat file.pdf | pdf2htmlEX fd://0 - >file.html`

Along with that --quiet option has been added, to avoid unnecessary processing info printing while in pipe mode.
