### PR TITLE
More explicit, and uniform, messages for throw statements

### DIFF
--- a/src/BackgroundRenderer/CairoBackgroundRenderer.cc
+++ b/src/BackgroundRenderer/CairoBackgroundRenderer.cc
@@ -219,7 +219,7 @@ void CairoBackgroundRenderer::embed_image(int pageno)
         auto path = html_renderer->str_fmt("%s/bg%x.svg", param.tmp_dir.c_str(), pageno);
         ifstream fin((char*)path, ifstream::binary);
         if(!fin)
-            throw string("Cannot read background image ") + (char*)path;
+            throw string("Cannot read background image: ") + (char*)path;
         f_page << "data:image/svg+xml;base64," << Base64Stream(fin);
     }
     else

--- a/src/BackgroundRenderer/SplashBackgroundRenderer.cc
+++ b/src/BackgroundRenderer/SplashBackgroundRenderer.cc
@@ -177,7 +177,7 @@ void SplashBackgroundRenderer::embed_image(int pageno)
             auto path = html_renderer->str_fmt("%s/bg%x.%s", param.tmp_dir.c_str(), pageno, format.c_str());
             ifstream fin((char*)path, ifstream::binary);
             if(!fin)
-                throw string("Cannot read background image ") + (char*)path;
+                throw string("Cannot read background image: ") + (char*)path;
 
             auto iter = FORMAT_MIME_TYPE_MAP.find(format);
             if(iter == FORMAT_MIME_TYPE_MAP.end())
@@ -204,7 +204,7 @@ void SplashBackgroundRenderer::dump_image(const char * filename, int x1, int y1,
 
     FILE * f = fopen(filename, "wb");
     if(!f)
-        throw string("Cannot open file for background image " ) + filename;
+        throw string("Cannot open file for background image: " ) + filename;
 
     // use unique_ptr to auto delete the object upon exception
     unique_ptr<ImgWriter> writer;
@@ -228,7 +228,7 @@ void SplashBackgroundRenderer::dump_image(const char * filename, int x1, int y1,
     }
 
     if(!writer->init(f, width, height, param.h_dpi, param.v_dpi))
-        throw "Cannot initialize image writer";
+        throw "Failed initializing image writer";
         
     auto * bitmap = getBitmap();
     assert(bitmap->getMode() == splashModeRGB8);
@@ -247,12 +247,12 @@ void SplashBackgroundRenderer::dump_image(const char * filename, int x1, int y1,
     
     if(!writer->writePointers(pointers.data(), height)) 
     {
-        throw "Cannot write background image";
+        throw "Failed writing background image";
     }
 
     if(!writer->close())
     {
-        throw "Cannot finish background image";
+        throw "Failed closing background image";
     }
 
     fclose(f);

--- a/src/HTMLRenderer/font.cc
+++ b/src/HTMLRenderer/font.cc
@@ -160,7 +160,7 @@ string HTMLRenderer::dump_embedded_font (GfxFont * font, FontInfo & info)
 
         ofstream outf(filepath, ofstream::binary);
         if(!outf)
-            throw string("Cannot open file ") + filepath + " for writing";
+            throw "Cannot open temporary font file for writing: " + filepath;
 
         char buf[1024];
         int len;

--- a/src/HTMLRenderer/general.cc
+++ b/src/HTMLRenderer/general.cc
@@ -404,9 +404,10 @@ void HTMLRenderer::post_process(void)
     }
 
     // apply manifest
-    ifstream manifest_fin((char*)str_fmt("%s/%s", param.data_dir.c_str(), MANIFEST_FILENAME.c_str()), ifstream::binary);
+    string manifest_fname(str_fmt("%s/%s", param.data_dir.c_str(), MANIFEST_FILENAME.c_str()));
+    ifstream manifest_fin(manifest_fname, ifstream::binary);
     if(!manifest_fin)
-        throw "Cannot open the manifest file";
+        throw "Cannot open the manifest file "+manifest_fname;
 
     bool embed_string = false;
     string line;

--- a/src/HTMLRenderer/general.cc
+++ b/src/HTMLRenderer/general.cc
@@ -108,7 +108,7 @@ void HTMLRenderer::process(PDFDoc *doc)
     {
         bg_renderer = BackgroundRenderer::getBackgroundRenderer(param.bg_format, this, param);
         if(!bg_renderer)
-            throw "Cannot initialize background renderer, unsupported format";
+            throw "Failed initializing background renderer, unsupported format";
         bg_renderer->init(doc);
 
         fallback_bg_renderer = BackgroundRenderer::getFallbackBackgroundRenderer(this, param);
@@ -133,7 +133,7 @@ void HTMLRenderer::process(PDFDoc *doc)
             auto page_fn = str_fmt("%s/%s", param.dest_dir.c_str(), filled_template_filename.c_str());
             f_curpage = new ofstream((char*)page_fn, ofstream::binary);
             if(!(*f_curpage))
-                throw string("Cannot open ") + (char*)page_fn + " for writing";
+                throw string("Cannot open page file for writing: ") + (char*)page_fn;
             set_stream_flags((*f_curpage));
 
             cur_page_filename = filled_template_filename;
@@ -328,7 +328,7 @@ void HTMLRenderer::pre_process(PDFDoc * doc)
         f_css.path = (char*)fn;
         f_css.fs.open(f_css.path, ofstream::binary);
         if(!f_css.fs)
-            throw string("Cannot open ") + (char*)fn + " for writing";
+            throw string("Cannot open temporary css file for writing: ") + (char*)fn;
         set_stream_flags(f_css.fs);
     }
 
@@ -348,7 +348,7 @@ void HTMLRenderer::pre_process(PDFDoc * doc)
         f_outline.path = (char*)fn;
         f_outline.fs.open(f_outline.path, ofstream::binary);
         if(!f_outline.fs)
-            throw string("Cannot open") + (char*)fn + " for writing";
+            throw string("Cannot open temporary outline file for writing: ") + (char*)fn;
 
         // might not be necessary
         set_stream_flags(f_outline.fs);
@@ -367,7 +367,7 @@ void HTMLRenderer::pre_process(PDFDoc * doc)
         f_pages.path = (char*)fn;
         f_pages.fs.open(f_pages.path, ofstream::binary);
         if(!f_pages.fs)
-            throw string("Cannot open ") + (char*)fn + " for writing";
+            throw string("Cannot open temporary page file for writing: ") + (char*)fn;
         set_stream_flags(f_pages.fs);
     }
 
@@ -399,7 +399,7 @@ void HTMLRenderer::post_process(void)
         auto fn = str_fmt("%s/%s", param.dest_dir.c_str(), param.output_filename.c_str());
         output.open((char*)fn, ofstream::binary);
         if(!output)
-            throw string("Cannot open ") + (char*)fn + " for writing";
+            throw string("Cannot open main html file for writing: ") + (char*)fn;
         set_stream_flags(output);
     }
 
@@ -407,7 +407,7 @@ void HTMLRenderer::post_process(void)
     string manifest_fname(str_fmt("%s/%s", param.data_dir.c_str(), MANIFEST_FILENAME.c_str()));
     ifstream manifest_fin(manifest_fname, ifstream::binary);
     if(!manifest_fin)
-        throw "Cannot open the manifest file "+manifest_fname;
+        throw "Cannot open the manifest file for reading: "+manifest_fname;
 
     bool embed_string = false;
     string line;
@@ -466,7 +466,7 @@ void HTMLRenderer::post_process(void)
                 {
                     ifstream fin(f_outline.path, ifstream::binary);
                     if(!fin)
-                        throw "Cannot open outline for reading";
+                        throw "Cannot open outline file for reading: " + f_outline.path;
                     output << fin.rdbuf();
                     output.clear(); // output will set fail big if fin is empty
                 }
@@ -475,7 +475,7 @@ void HTMLRenderer::post_process(void)
             {
                 ifstream fin(f_pages.path, ifstream::binary);
                 if(!fin)
-                    throw "Cannot open pages for reading";
+                    throw "Cannot open pages file for reading: " + f_pages.path;
                 output << fin.rdbuf();
                 output.clear(); // output will set fail bit if fin is empty
             }
@@ -553,7 +553,7 @@ void HTMLRenderer::embed_file(ostream & out, const string & path, const string &
     {
         ifstream fin(path, ifstream::binary);
         if(!fin)
-            throw string("Cannot open file ") + path + " for embedding";
+            throw "Cannot open embedding input file for reading: " + path;
         out << entry.prefix_embed;
 
         if(entry.base64_encode)
@@ -577,11 +577,11 @@ void HTMLRenderer::embed_file(ostream & out, const string & path, const string &
         {
             ifstream fin(path, ifstream::binary);
             if(!fin)
-                throw string("Cannot copy file: ") + path;
-            auto out_path = param.dest_dir + "/" + fn;
+                throw "Cannot open embedding input file (copy mode) for reading: " + path;
+            string out_path = param.dest_dir + "/" + fn;
             ofstream out(out_path, ofstream::binary);
             if(!out)
-                throw string("Cannot open file ") + path + " for embedding";
+                throw "Cannot open embedding output file for writing: " + out_path;
             out << fin.rdbuf();
             out.clear(); // out will set fail big if fin is empty
         }

--- a/src/pdf2htmlEX.cc
+++ b/src/pdf2htmlEX.cc
@@ -393,19 +393,17 @@ int main(int argc, char **argv)
     PDFDoc * doc = nullptr;
     try
     {
-        {
-            GooString * ownerPW = (param.owner_password == "") ? (nullptr) : (new GooString(param.owner_password.c_str()));
-            GooString * userPW = (param.user_password == "") ? (nullptr) : (new GooString(param.user_password.c_str()));
-            GooString fileName(param.input_filename.c_str());
+        GooString * ownerPW = (param.owner_password == "") ? (nullptr) : (new GooString(param.owner_password.c_str()));
+        GooString * userPW = (param.user_password == "") ? (nullptr) : (new GooString(param.user_password.c_str()));
+        GooString fileName(param.input_filename.c_str());
 
-            doc = PDFDocFactory().createPDFDoc(fileName, ownerPW, userPW);
+        doc = PDFDocFactory().createPDFDoc(fileName, ownerPW, userPW);
 
-            delete userPW;
-            delete ownerPW;
-        }
+        delete userPW;
+        delete ownerPW;
 
         if (!doc->isOk())
-            throw "Cannot read the file";
+            throw "Cannot read the PDF input file: " + param.input_filename;
 
         // check for copy permission
         if (!doc->okToCopy())

--- a/src/util/path.cc
+++ b/src/util/path.cc
@@ -40,7 +40,7 @@ void create_directories(const string & path)
                 return;
         }
 
-        throw string("Cannot create directory: ") + path;
+        throw "Cannot create directories: " + path;
     }
 }
 


### PR DESCRIPTION
When a file cannot be opened: include kind-of-file in error message. Terminate error message with colon + filename.