### PR TITLE
Position:relative better styling for wrapper when printing

### DIFF
--- a/share/base.css.in
+++ b/share/base.css.in
@@ -64,6 +64,7 @@
   }
   #sidebar { display:none; }
   #page-container {
+    position: relative;
     width:auto;
     height:auto;
     overflow:visible;


### PR DESCRIPTION
Certain web browsers (e.g. Presto-based Opera) or HTML->PDF software (e.g. Prince) respects absolute positioning and takes content out of the normal flow.
This means pagination of the printed document won't work as expected any more if ALL content is inside a position:absolute element. 

Printing or generating PDFs from pdf2htmlEX-generated documents would work better if the #page-container element wrapping everything is styled as position:relative for ``@media print`` mode.